### PR TITLE
logs 1st death if user starts bot from a death state

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/core/manager/RepairManager.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/manager/RepairManager.java
@@ -58,7 +58,12 @@ public class RepairManager implements Manager {
     }
 
     public boolean isDead() {
-        return API.readMemoryBoolean(userDataAddress + 0x4C);
+        if (userDataAddress != 0)
+            return API.readMemoryBoolean(userDataAddress + 0x4C);
+        else if (repairAddress != 0)
+            return API.readMemoryBoolean(repairAddress + 40);
+        else updateRepairAddr();
+        return false;
     }
 
     public boolean canRespawn(int option) {


### PR DESCRIPTION
When darkbot is started from death state userDataAddres is 0 so nothing is logged.

Not sure if should also add this check but I noticed one time 0x30 offset was null causing offset at 40 from repairAddress to be always false. (this only happened once out of like a hundred times I died)
           ``` return API.readMemoryBoolean(repairAddress + 40) ||
                   API.readMemoryLong(repairAddress + 0x30) == 0;```