### PR TITLE
PortalJumper desync prevention

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/modules/utils/PortalJumper.java
+++ b/src/main/java/com/github/manolo8/darkbot/modules/utils/PortalJumper.java
@@ -3,6 +3,8 @@ package com.github.manolo8.darkbot.modules.utils;
 import com.github.manolo8.darkbot.core.entities.Portal;
 import com.github.manolo8.darkbot.core.manager.HeroManager;
 
+import static com.github.manolo8.darkbot.Main.API;
+
 public class PortalJumper {
 
     private HeroManager hero;
@@ -24,7 +26,9 @@ public class PortalJumper {
             last = target;
             lastJumpStart = System.currentTimeMillis();
         } else if (System.currentTimeMillis() - lastJumpStart > 5_000) {
-            hero.drive.clickCenter(true, target.locationInfo.now);
+            if (!API.readMemoryBoolean(target.clickable.address, 64, 32)) { // Do not try moving if jump button in sync
+                hero.drive.clickCenter(true, target.locationInfo.now);
+            }
             lastJumpStart = System.currentTimeMillis();
         }
     }


### PR DESCRIPTION
I still suggest implementing this check on pressing jump button so bot and plugins will never jump into wrong maps/galaxy gates
I couldn't start a jump earlier than jump button activates, maybe game behaviour changed, spamming J before jump button activates is useless right now.