### PR TITLE
Changed default value of 'Pause after refresh'

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/config/Config.java
+++ b/src/main/java/com/github/manolo8/darkbot/config/Config.java
@@ -164,7 +164,7 @@ public class Config {
     public static class Miscellaneous {
         public @Option boolean REFRESH_AFTER_REVIVE = false;
         public @Option @Num(max = 60 * 12, step = 10) int REFRESH_TIME = 60;
-        public @Option @Num(max = 60 * 12, step = 10) int PAUSE_FOR = 5;
+        public @Option @Num(max = 60 * 12, step = 10) int PAUSE_FOR = 0;
         public @Option boolean RESET_REFRESH = true;
         public @Option @Editor(JPercentField.class) double DRONE_REPAIR_PERCENTAGE = 0.9;
         public @Option boolean HONOR_LOST_EXACT = true;


### PR DESCRIPTION
Mainly this is to avoid the many 'issues' that we come across in the support channels. It's better if this is disabled, and then if anyone can, they can enable it.