### PR TITLE
Tweak min wait before revive

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/config/Config.java
+++ b/src/main/java/com/github/manolo8/darkbot/config/Config.java
@@ -76,7 +76,7 @@ public class Config {
             public @Option ShipConfig REPAIR = new ShipConfig(1, '9');
             public @Option @Num(min = 1, max = 9999) int MAX_DEATHS = 10;
             public @Option @Editor(JListField.class) @Options(ReviveSpotSupplier.class) long REVIVE_LOCATION = 1L;
-            public @Option @Num(min = 2, max = 60, step = 10) int WAIT_BEFORE_REVIVE = 3;
+            public @Option @Num(min = 5, max = 60, step = 10) int WAIT_BEFORE_REVIVE = 5;
             public @Option @Num(min = 3, max = 15 * 60, step = 10) int WAIT_AFTER_REVIVE = 90;
         }
 


### PR DESCRIPTION
If you set WAIT_BEFORE_REVIVE as low as 2 sometimes it just causes you to be stuck on death screen without the repair popup and if you refresh you find out client/server didn't register the repair.