### PR TITLE
Restore compatibility of Rsb.AMMO_REFRESH with old plugins

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/config/Config.java
+++ b/src/main/java/com/github/manolo8/darkbot/config/Config.java
@@ -130,6 +130,7 @@ public class Config {
         public static class Rsb {
             public @Option boolean ENABLED = false;
             public @Option Character KEY = '3';
+            public @Deprecated int AMMO_REFRESH = 3500;
         }
         public @Option Character AMMO_KEY = '1';
         public @Option Character SHIP_ABILITY;


### PR DESCRIPTION
Otherwise plugins who copied Attacker or used this variable for some reason, will break.