### PR TITLE
Changed loginUrl

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/utils/login/LoginUtils.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/login/LoginUtils.java
@@ -110,7 +110,7 @@ public class LoginUtils {
     }
 
     public static void usernameLogin(LoginData loginData) {
-        String loginUrl = Http.create("https://www.darkorbit.com/")
+        String loginUrl = Http.create("https://lp.darkorbit.com/")
                 .consumeInputStream(LoginUtils::getLoginUrl);
 
         CookieManager cookieManager = new CookieManager();


### PR DESCRIPTION
Changed the loginUrl because there are quite a lot of people who has issue with the captcha and as far as I know this URL does not have a captcha check I even tried many times to get that captcha with filling in wrong credentials but even after 10-15 times i did not saw any captcha so this should just work fine and also it's better for the support as they have no longer need to explain how to do SID login nor we have people saying (WHY DOES LOGIN FAIL?!) please think about it :) thanks