### PR TITLE
Add missing fields to new hangar API

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/backpage/hangar/EquippableItem.java
+++ b/src/main/java/com/github/manolo8/darkbot/backpage/hangar/EquippableItem.java
@@ -8,12 +8,39 @@ public class EquippableItem extends Item {
     private Map<String, String> properties;
     @SerializedName("Q") private Integer quantity;
 
+    @SerializedName("EQH") private String equippedHangar;
+    @SerializedName("EQC") private String equippedConfig;
+    @SerializedName("EQT") private String equippedTarget;
+
+    @SerializedName("SL") private int shieldLevel;
+    @SerializedName("DL") private int damageLevel;
+
     public Map<String, String> getProperties() {
         return properties;
     }
 
     public Integer getQuantity() {
         return quantity;
+    }
+
+    public String getEquippedHangar() {
+        return equippedHangar;
+    }
+
+    public String getEquippedConfig() {
+        return equippedConfig;
+    }
+
+    public String getEquippedTarget() {
+        return equippedTarget;
+    }
+
+    public int getShieldLevel() {
+        return shieldLevel;
+    }
+
+    public int getDamageLevel() {
+        return damageLevel;
     }
 
     @Override


### PR DESCRIPTION
Currently there's no way to get these fields without using the legacy hangar api in darkbot