### PR TITLE
Fix issues with pathfinder

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/Main.java
+++ b/src/main/java/com/github/manolo8/darkbot/Main.java
@@ -56,7 +56,7 @@ import java.util.stream.Stream;
 
 public class Main extends Thread implements PluginListener, BotAPI {
 
-    public static final Version VERSION      = new Version("1.13.17 beta 102");
+    public static final Version VERSION      = new Version("1.13.17 beta 103 alpha 1");
     public static final Object UPDATE_LOCKER = new Object();
     public static final Gson GSON            = new GsonBuilder()
             .setPrettyPrinting()

--- a/src/main/java/com/github/manolo8/darkbot/core/utils/Drive.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/utils/Drive.java
@@ -124,12 +124,12 @@ public class Drive implements MovementAPI {
     }
 
     public boolean canMove(Location location) {
-        return !map.isOutOfMap(location.x, location.y) && pathFinder.canMove((int) location.x, (int) location.y);
+        return !map.isOutOfMap(location.x, location.y) && pathFinder.canMove(location.x, location.y);
     }
 
+    @Deprecated /* Use getClosestDistance(Location) instead */
     public double closestDistance(Location location) {
-        PathPoint closest = pathFinder.fixToClosest(new PathPoint((int) location.x, (int) location.y));
-        return location.distance(closest.toLocation());
+        return getClosestDistance(location);
     }
 
     public double distanceBetween(Location loc, int x, int y) {
@@ -259,8 +259,8 @@ public class Drive implements MovementAPI {
 
     @Override
     public double getClosestDistance(double x, double y) {
-        PathPoint closest = pathFinder.fixToClosest(new PathPoint((int) x, (int) y));
-        return closest.distanceTo(x, y);
+        Locatable from = Locatable.of(x, y);
+        return from.distanceTo(pathFinder.fixToClosest(from));
     }
 
     @Override

--- a/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/AreaImpl.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/AreaImpl.java
@@ -11,7 +11,7 @@ public abstract class AreaImpl implements Area {
 
     public boolean changed;
 
-    public abstract PathPoint toSide(Locatable point);
+    public abstract Locatable toSide(Locatable point);
 
     public abstract Collection<PathPoint> getPoints(@NotNull PathFinder pf);
 

--- a/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/CircleImpl.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/CircleImpl.java
@@ -36,10 +36,10 @@ public class CircleImpl extends AreaImpl implements Area.Circle {
     }
 
     @Override
-    public PathPoint toSide(Locatable point) {
+    public Locatable toSide(Locatable point) {
         double angle = Math.atan2(y - point.getY(), x - point.getX());
 
-        return new PathPoint((x - Math.cos(angle) * radius), (y - Math.sin(angle) * radius));
+        return Locatable.of(x - Math.cos(angle) * radius, y - Math.sin(angle) * radius);
     }
 
     @Override

--- a/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/PathFinder.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/PathFinder.java
@@ -2,7 +2,8 @@ package com.github.manolo8.darkbot.core.utils.pathfinder;
 
 import com.github.manolo8.darkbot.Main;
 import com.github.manolo8.darkbot.core.manager.MapManager;
-import com.github.manolo8.darkbot.core.utils.Location;
+import eu.darkbot.api.game.other.Locatable;
+import eu.darkbot.api.game.other.Location;
 
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -24,73 +25,68 @@ public class PathFinder implements eu.darkbot.api.utils.PathFinder {
         this.points = new HashSet<>();
     }
 
-    public LinkedList<PathPoint> createRote(Location current, Location destination) {
-        return createRote(
-                new PathPoint((int) current.x, (int) current.y),
-                new PathPoint((int) destination.x, (int) destination.y)
-        );
-    }
-
-    public LinkedList<PathPoint> createRote(PathPoint current, PathPoint destination) {
-        LinkedList<PathPoint> paths = new LinkedList<>();
+    public LinkedList<PathPoint> createRote(Locatable current, Locatable destination) {
         current = fixToClosest(current);
         destination = fixToClosest(destination);
 
         if (hasLineOfSight(current, destination)) {
-            paths.add(destination);
-            return paths;
+            LinkedList<PathPoint> list = new LinkedList<>();
+            list.add(new PathPoint(destination.getX(), destination.getY()));
+            return list;
         }
 
-        current.fillLineOfSight(this);
-        destination.fillLineOfSight(this);
+        PathPoint from = new PathPoint(current.getX(), current.getY());
+        PathPoint to = new PathPoint(destination.getX(), destination.getY());
+        from.fillLineOfSight(this);
+        to.fillLineOfSight(this);
 
-        new PathFinderCalculator(current, destination)
-                .fillGeneratedPathTo(paths);
+        LinkedList<PathPoint> paths = PathFinderCalculator.calculate(from, to);
 
         // If no possible path is found, try to fly straight
-        if (paths.isEmpty()) paths.add(destination);
-
+        if (paths.isEmpty()) paths.add(to);
         return paths;
     }
 
-    public PathPoint fixToClosest(PathPoint point) {
-        double initialX = point.x, initialY = point.y;
+    public Locatable fixToClosest(final Locatable initial) {
+        Location result = Location.of(initial.getX(), initial.getY());
 
-        AreaImpl area = areaTo(point);
+        AreaImpl area = areaTo(result);
         if (area != null) {
-            point = area.toSide(point); // Inside an area, get out of it
-            area = areaTo(point); // See if leaving an area got us inside another one
+            result.setTo(area.toSide(result)); // Inside an area, get out of it
+            area = areaTo(result); // See if leaving an area got us inside another one
         }
-        if (map.isOutOfMap(point.x, point.y)) { // In radiation, get out of it
-            point.x = Math.min(Math.max(point.x, 0), MapManager.internalWidth);
-            point.y = Math.min(Math.max(point.y, 0), MapManager.internalHeight);
-            if (areaTo(point) == null) return point; // Got out of rad and not in area
-        } else if (area == null) return point; // Inside map & not in area (anymore)
+        if (isOutOfMap(result)) { // In radiation, get out of it
+            result.setTo(
+                    Math.min(Math.max(result.getX(), 0), MapManager.internalWidth),
+                    Math.min(Math.max(result.getY(), 0), MapManager.internalHeight));
+            if (canMove(result)) return result; // Got out of rad and not in area
+        } else if (area == null) return result; // Inside map & not in area (anymore)
 
         // Search for point in spiral pattern
         double angle = 0, distance = 0;
         do {
-            point.x = initialX - (int) (cos(angle) * distance);
-            point.y = initialY - (int) (sin(angle) * distance);
+            result.setTo(
+                    initial.getX() - (int) (cos(angle) * distance),
+                    initial.getY() - (int) (sin(angle) * distance));
             angle += 0.3;
             distance += 2;
-        } while (areaTo(point) != null || map.isOutOfMap(point.x, point.y) && distance < 20000);
+        } while (areaTo(initial) != null || isOutOfMap(initial.getX(), initial.getY()) && distance < 20000);
 
         // Worst case scenario, just pick the closest known path point
         if (distance >= 20000) {
-            PathPoint closest = closest(point);
-            if (closest != null) return closest;
+            PathPoint closest = closest(initial);
+            if (closest != null) return closest.toLocation();
         }
-        return point;
+        return initial;
     }
 
-    private PathPoint closest(PathPoint point) {
+    private PathPoint closest(Locatable point) {
 
         double distance = 0;
         PathPoint current = null;
 
         for (PathPoint loop : points) {
-            double cd = loop.distance(point);
+            double cd = loop.distanceTo(point);
 
             if (current == null || cd < distance) {
                 current = loop;
@@ -102,8 +98,16 @@ public class PathFinder implements eu.darkbot.api.utils.PathFinder {
         return current;
     }
 
+    public boolean isOutOfMap(Locatable loc) {
+        return map.isOutOfMap(loc.getX(), loc.getY());
+    }
+
     public boolean isOutOfMap(double x, double y) {
         return map.isOutOfMap(x, y);
+    }
+
+    public boolean canMove(Locatable loc) {
+        return canMove(loc.getX(), loc.getY());
     }
 
     public boolean canMove(double x, double y) {
@@ -125,11 +129,11 @@ public class PathFinder implements eu.darkbot.api.utils.PathFinder {
         return true;
     }
 
-    private AreaImpl areaTo(PathPoint point) {
-        return obstacleHandler.stream().filter(a -> a.containsPoint(point.x, point.y)).findAny().orElse(null);
+    private AreaImpl areaTo(Locatable point) {
+        return obstacleHandler.stream().filter(a -> a.containsPoint(point.getX(), point.getY())).findAny().orElse(null);
     }
 
-    boolean hasLineOfSight(PathPoint point1, PathPoint point2) {
+    boolean hasLineOfSight(Locatable point1, Locatable point2) {
         return obstacleHandler.stream().noneMatch(a -> a.intersectsLine(point1, point2));
     }
 

--- a/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/PathFinderCalculator.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/PathFinderCalculator.java
@@ -16,15 +16,19 @@ public class PathFinderCalculator {
 
     private final List<PathPoint> fragmentedPath;
 
-    public PathFinderCalculator(PathPoint come,
-                                PathPoint destination) {
-
-        this.come = come;
-        this.destination = destination;
+    private PathFinderCalculator(PathPoint from, PathPoint to) {
+        this.come = from;
+        this.destination = to;
 
         this.fragmentedPath = new ArrayList<>();
         this.closedList = new HashSet<>();
         this.openList = new HashSet<>();
+    }
+
+    public static LinkedList<PathPoint> calculate(PathPoint from, PathPoint to) {
+        LinkedList<PathPoint> list = new LinkedList<>();
+        new PathFinderCalculator(from, to).fillGeneratedPathTo(list);
+        return list;
     }
 
     public void fillGeneratedPathTo(LinkedList<PathPoint> target) {
@@ -55,7 +59,7 @@ public class PathFinderCalculator {
 
         PathPoint current = come;
 
-        current.f = (int) destination.distance(come);
+        current.f = (int) destination.distanceTo(come);
         current.g = 0;
         current.s = 0;
 
@@ -79,14 +83,14 @@ public class PathFinderCalculator {
             if (closedList.contains(neighbor))
                 continue;
 
-            int g = current.g + (int) current.distance(neighbor);
+            int g = current.g + (int) current.distanceTo(neighbor);
 
             if (!openList.add(neighbor) && g >= neighbor.g)
                 continue;
 
             neighbor.g = g;
             neighbor.s = current.s + 1;
-            neighbor.f = g + (int) destination.distance(neighbor);
+            neighbor.f = g + (int) destination.distanceTo(neighbor);
 
             fragmentedPath.add(neighbor);
         }
@@ -109,7 +113,7 @@ public class PathFinderCalculator {
 
             if (!current.lineOfSight.contains(loop)) continue;
 
-            int csum = loop.g + (int) loop.distance(current);
+            int csum = loop.g + (int) loop.distanceTo(current);
 
             if (current.s == loop.s + 1 && (closest == null || csum < sum)) {
                 closest = loop;

--- a/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/PathPoint.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/PathPoint.java
@@ -11,8 +11,8 @@ import static java.lang.Math.sqrt;
 
 public class PathPoint implements Locatable {
 
-    public double x;
-    public double y;
+    public final double x;
+    public final double y;
 
     public int f;
     public int g;
@@ -23,10 +23,6 @@ public class PathPoint implements Locatable {
     public PathPoint(double x, double y) {
         this.x = x;
         this.y = y;
-    }
-
-    public double distance(PathPoint o) {
-        return sqrt(pow(x - o.x, 2) + pow(y - o.y, 2));
     }
 
     public void fillLineOfSight(PathFinder finder) {

--- a/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/RectangleImpl.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/utils/pathfinder/RectangleImpl.java
@@ -14,6 +14,8 @@ import static java.lang.Math.min;
 
 public class RectangleImpl extends AreaImpl implements Area.Rectangle {
 
+    private static final int MARGIN = 5;
+    
     public double minX;
     public double minY;
     public double maxX;
@@ -39,16 +41,15 @@ public class RectangleImpl extends AreaImpl implements Area.Rectangle {
         double diffLeft = point.getX() - minX, diffRight = maxX - point.getX();
         double diffTop = point.getY() - minY, diffBottom = maxY - point.getY();
 
+        double newX = point.getX(), newY = point.getY();
+
         double min = min(min(diffBottom, diffTop), min(diffLeft, diffRight));
+        if (min == diffTop) newY = minY - MARGIN;
+        else if (min == diffBottom) newY = maxY + MARGIN;
+        else if (min == diffLeft) newX = minX - MARGIN;
+        else newX = (int) maxX + MARGIN;
 
-        PathPoint result = new PathPoint(point.getX(), point.getY());
-
-        if (min == diffTop) result.y = (int) minY - 5;
-        else if (min == diffBottom) result.y = (int) maxY + 5;
-        else if (min == diffLeft) result.x = (int) minX - 5;
-        else result.x = (int) maxX + 5;
-
-        return result;
+        return new PathPoint(newX, newY);
     }
 
     public Collection<PathPoint> getPoints(@NotNull eu.darkbot.api.utils.PathFinder pf) {
@@ -62,8 +63,12 @@ public class RectangleImpl extends AreaImpl implements Area.Rectangle {
     }
 
     private enum Corner {
-        TOP_LEFT(-5, -5), TOP_RIGHT(5, -5), BOTTOM_LEFT(-5, 5), BOTTOM_RIGHT(5, 5);
-        final int xDiff, yDiff;
+        TOP_LEFT(-MARGIN, -MARGIN),
+        TOP_RIGHT(MARGIN, -MARGIN),
+        BOTTOM_LEFT(-MARGIN, MARGIN),
+        BOTTOM_RIGHT(MARGIN, MARGIN);
+
+        private final int xDiff, yDiff;
 
         Corner(int x, int y) {
             this.xDiff = x;

--- a/src/main/java/com/github/manolo8/darkbot/modules/CollectorModule.java
+++ b/src/main/java/com/github/manolo8/darkbot/modules/CollectorModule.java
@@ -206,7 +206,7 @@ public class CollectorModule implements Module {
     private boolean canCollect(Box box) {
         return box.boxInfo.collect
                 && !box.isCollected()
-                && drive.closestDistance(box.locationInfo.now) < 200
+                && drive.getClosestDistance(box.locationInfo.now) < 200
                 && (!isResource(box.type) || main.statsManager.deposit < main.statsManager.depositTotal)
                 && !isContested(box);
     }

--- a/src/main/java/com/github/manolo8/darkbot/modules/LootModule.java
+++ b/src/main/java/com/github/manolo8/darkbot/modules/LootModule.java
@@ -103,7 +103,7 @@ public class LootModule implements Module {
     }
 
     protected void ignoreInvalidTarget() {
-        double closestDist = drive.closestDistance(attack.target.locationInfo.now);
+        double closestDist = drive.getClosestDistance(attack.target.locationInfo.now);
         if (!main.mapManager.isTarget(attack.target)) {
             if (closestDist > 600) {
                 attack.target.setTimerTo(1000);
@@ -216,7 +216,7 @@ public class LootModule implements Module {
                 .filter(n -> (n == attack.target && hero.isAttacking(attack.target)) ||
                         ((!config.GENERAL.ROAMING.ONLY_KILL_PREFERRED || main.mapManager.preferred.contains(n.locationInfo.now))
                                 && shouldKill(n)
-                                && drive.closestDistance(n.locationInfo.now) < 500))
+                                && drive.getClosestDistance(n.locationInfo.now) < 500))
                 .min(Comparator.<Npc>comparingInt(n -> n.npcInfo.priority - (n == attack.target ? extraPriority : 0))
                         .thenComparing(n -> n.health.hpPercent())
                         .thenComparing(n -> n.locationInfo.now.distance(location))).orElse(null);

--- a/src/main/java/com/github/manolo8/darkbot/modules/utils/PortalJumper.java
+++ b/src/main/java/com/github/manolo8/darkbot/modules/utils/PortalJumper.java
@@ -27,7 +27,7 @@ public class PortalJumper {
     }
 
     public boolean travel(Portal target) {
-        double leniency = Math.min(200 + drive.closestDistance(target.locationInfo.now), 600);
+        double leniency = Math.min(200 + drive.getClosestDistance(target.locationInfo.now), 600);
         if (target.locationInfo.isLoaded() && drive.movingTo().distance(target.locationInfo.now) > leniency) {
             drive.move(Location.of(target.locationInfo.now, Math.random() * Math.PI * 2, Math.random() * 200));
             return false;


### PR DESCRIPTION
Updates path finder to use Locatable more than PathPoint where not needed, and makes PathPoint's x and y immutable to avoid issues like this to happen in the future. fixToClosest could (in some situations) return the closest PathPoint, and since routes to "start" and "end" points are added, and later, removed, it would cause the PathPoint to lose its line of sights with other points.