### PR TITLE
Added missing fields of EquippableItem

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/backpage/hangar/EquippableItem.java
+++ b/src/main/java/com/github/manolo8/darkbot/backpage/hangar/EquippableItem.java
@@ -15,6 +15,9 @@ public class EquippableItem extends Item {
     @SerializedName("SL") private int shieldLevel;
     @SerializedName("DL") private int damageLevel;
 
+    @SerializedName("SUS") private String shipUpgradeShips;
+    @SerializedName("SUM") private String shipUpgradeModifiers;
+
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -42,6 +45,10 @@ public class EquippableItem extends Item {
     public int getDamageLevel() {
         return damageLevel;
     }
+
+    public String getShipUpgradeShips() { return shipUpgradeShips; }
+
+    public String getShipUpgradeModifiers() { return shipUpgradeModifiers; }
 
     @Override
     public String toString() {

--- a/src/main/java/com/github/manolo8/darkbot/backpage/hangar/EquippableItem.java
+++ b/src/main/java/com/github/manolo8/darkbot/backpage/hangar/EquippableItem.java
@@ -46,9 +46,13 @@ public class EquippableItem extends Item {
         return damageLevel;
     }
 
-    public String getShipUpgradeShips() { return shipUpgradeShips; }
+    public String getShipUpgradeShips() {
+        return shipUpgradeShips;
+    }
 
-    public String getShipUpgradeModifiers() { return shipUpgradeModifiers; }
+    public String getShipUpgradeModifiers() {
+        return shipUpgradeModifiers;
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
Added support for two fields linked to Ship Upgrade Modules: ships (SUS) and modifiers (SUM).

These fields can be accessed through properties field, but there ships are given as numbers (ship ID), while in the new field they are given as text (e. g. ship_goliath). So with the field SUS you can get the ships of a Ship Upgrade Module in a human readable way.