### PR TITLE
Option to enable UDP logging in addition of file logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>9</source>
+                    <target>9</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/com/github/manolo8/darkbot/Bot.java
+++ b/src/main/java/com/github/manolo8/darkbot/Bot.java
@@ -15,10 +15,7 @@ public class Bot {
     public static void main(String[] args) throws IOException {
         // You can enable hardware acceleration via adding jvm arg: -Dsun.java2d.opengl=True
 
-        if (System.console() == null
-                && Bot.class.getProtectionDomain().getCodeSource().getLocation().getPath().endsWith(".jar")) {
-            LogUtils.setOutputToFile();
-        }
+        LogUtils.setOutputToFile();
         try {
             UIManager.getFont("Label.font"); // Prevents a linux crash
             UIManager.setLookAndFeel(new FlatDarkLaf());

--- a/src/main/java/com/github/manolo8/darkbot/utils/BetterLogUtils.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/BetterLogUtils.java
@@ -1,0 +1,39 @@
+package com.github.manolo8.darkbot.utils;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.time.LocalDateTime;
+
+public class BetterLogUtils extends LogUtils {
+    private DatagramSocket socket ;
+    //singleton
+    private static BetterLogUtils instance;
+    public static BetterLogUtils getInstance() {
+        if (instance == null) instance = new BetterLogUtils();
+        return instance;
+    }
+    private BetterLogUtils() {
+        try {
+            //get localhost IP address
+            socket = new DatagramSocket();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    public void PrintLn(String message)
+    {
+        try {
+            InetAddress adds = InetAddress.getLoopbackAddress();
+            DatagramSocket ds = new DatagramSocket();
+            String msg = "["+ ProcessHandle.current().pid()+"]"+"[" + LocalDateTime.now().format(LOG_DATE) + "] " + message + "\n";
+            DatagramPacket dp = new DatagramPacket(msg.getBytes(),msg.length(), adds, 7504);
+            ds.send(dp);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/github/manolo8/darkbot/utils/LogUtils.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/LogUtils.java
@@ -97,6 +97,31 @@ public class LogUtils {
         @Override
         public void println(String string) {
             super.println("[" + LocalDateTime.now().format(LOG_DATE) + "] " + string);
+            Path pathLogConfig = Paths.get("./logConfig.conf");
+            boolean allowUdpLogging = false;
+            if(Files.exists(pathLogConfig))
+            {
+                try {
+                    String content = Files.readAllLines(pathLogConfig).get(0);
+                    if (content.split("=")[1].equals("true"))
+                    {
+                        allowUdpLogging = true;
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            else {
+                try {
+                    Files.write(pathLogConfig,"allow_udp_logs=false".getBytes());
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            if (allowUdpLogging)
+            {
+                BetterLogUtils.getInstance().PrintLn(string);
+            }
         }
     }
 }


### PR DESCRIPTION
### UDP logging
Hello this is the cleaner version of my previous pull request that I've close.

The goal of this is to be able to read logs from another process using UDP on port 7504. By not making this as a plugins allow you to monitor your bot even before login to check if the bot has successfully started or if an error occured.

### What's new ? 
Possibility to enable UDP logging by setting "true" in the logConfig.conf file (Automatically created if missing with default configuration to false) in addition of file logging.

