### PR TITLE
Add autologin by SID

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/gui/utils/Strings.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/utils/Strings.java
@@ -34,7 +34,7 @@ public class Strings {
                 .replaceAll("m[i1]m[e3][s5][i1][s5]", "mimesis");
     }
 
-    public static boolean isEmpty(String s){
+    public static boolean isEmpty(String s) {
         return s == null || s.isEmpty();
     }
 }

--- a/src/main/java/com/github/manolo8/darkbot/gui/utils/Strings.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/utils/Strings.java
@@ -34,4 +34,7 @@ public class Strings {
                 .replaceAll("m[i1]m[e3][s5][i1][s5]", "mimesis");
     }
 
+    public static boolean isEmpty(String s){
+        return s == null || s.isEmpty();
+    }
 }

--- a/src/main/java/com/github/manolo8/darkbot/utils/StartupParams.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/StartupParams.java
@@ -1,5 +1,6 @@
 package com.github.manolo8.darkbot.utils;
 
+import com.github.manolo8.darkbot.gui.utils.Strings;
 import eu.darkbot.api.API;
 import eu.darkbot.util.function.ThrowingFunction;
 
@@ -89,7 +90,7 @@ public class StartupParams implements API.Singleton {
         }
     }
 
-    public AutoLoginProps getAutologinInstance(){
+    public AutoLoginProps getAutoLoginProps(){
         return (AutoLoginProps) startupParams.getOrDefault(LaunchArg.LOGIN, null);
     }
 
@@ -125,34 +126,57 @@ public class StartupParams implements API.Singleton {
                 .collect(Collectors.joining(","));
     }
 
-    public static class AutoLoginProps {
+    public static class AutoLoginProps extends Properties {
         private final String path;
-        private final Properties props;
 
         private AutoLoginProps(String path) throws IOException {
             this.path = path;
-            props = new Properties();
             try (InputStreamReader reader = new InputStreamReader(new FileInputStream(path), StandardCharsets.UTF_8)) {
-                props.load(reader);
+                load(reader);
             }
             System.out.println("Loaded startup properties file");
         }
-        public String getAutoLoginValue(PropertyKey key) {
-            return props.getProperty(key.toString());
+
+        public String getUsername() {
+            return getProperty(PropertyKey.USERNAME.toString());
         }
 
-        public char[] getAutoLoginMasterPassword() {
-            String masterPassword = getAutoLoginValue(PropertyKey.MASTER_PASSWORD);
+        public String getPassword() {
+            return getProperty(PropertyKey.PASSWORD.toString());
+        }
+
+        public char[] getMasterPassword() {
+            String masterPassword = getProperty(PropertyKey.MASTER_PASSWORD.toString());
             return masterPassword == null ? null : masterPassword.toCharArray();
         }
 
-        public void setAutoLoginProp(PropertyKey key, String val) {
-            props.setProperty(key.toString(), val);
+        public String getServer() {
+            return getProperty(PropertyKey.SERVER.toString());
+        }
+
+        public String getSID() {
+            return getProperty(PropertyKey.SID.toString());
+        }
+
+        public boolean isAllowStoreSID() {
+            return Boolean.parseBoolean(getProperty(PropertyKey.ALLOW_STORE_SID.toString()));
+        }
+
+        public boolean isPossibleSIDLogin() {
+            return !Strings.isEmpty(getSID()) && !Strings.isEmpty(getServer());
+        }
+
+        public void setServer(String server) {
+            setProperty(PropertyKey.SERVER.toString(), server);
+        }
+
+        public void setSID(String sid) {
+            setProperty(PropertyKey.SID.toString(), sid);
         }
 
         public void updateLoginFile() {
             try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(path), StandardCharsets.UTF_8)) {
-                props.store(writer, null);
+                store(writer, null);
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/com/github/manolo8/darkbot/utils/StartupParams.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/StartupParams.java
@@ -63,7 +63,7 @@ public class StartupParams implements API.Singleton {
     }
 
     public enum PropertyKey {
-        USERNAME, PASSWORD, MASTER_PASSWORD, SERVER, SID;
+        USERNAME, PASSWORD, MASTER_PASSWORD, SERVER, SID, ALLOW_STORE_SID;
         @Override
         public String toString() {
             return this.name().toLowerCase(Locale.ROOT);

--- a/src/main/java/com/github/manolo8/darkbot/utils/StartupParams.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/StartupParams.java
@@ -126,57 +126,67 @@ public class StartupParams implements API.Singleton {
                 .collect(Collectors.joining(","));
     }
 
-    public static class AutoLoginProps extends Properties {
+    public static class AutoLoginProps {
+        private final Properties prop;
         private final String path;
 
         private AutoLoginProps(String path) throws IOException {
+            this.prop = new Properties();
             this.path = path;
             try (InputStreamReader reader = new InputStreamReader(new FileInputStream(path), StandardCharsets.UTF_8)) {
-                load(reader);
+                prop.load(reader);
             }
             System.out.println("Loaded startup properties file");
         }
 
+        private String getProperty(PropertyKey key) {
+            return prop.getProperty(key.toString());
+        }
+
+        private void setProperty(PropertyKey key, String val) {
+            prop.setProperty(key.toString(), val);
+        }
+
         public String getUsername() {
-            return getProperty(PropertyKey.USERNAME.toString());
+            return getProperty(PropertyKey.USERNAME);
         }
 
         public String getPassword() {
-            return getProperty(PropertyKey.PASSWORD.toString());
+            return getProperty(PropertyKey.PASSWORD);
         }
 
         public char[] getMasterPassword() {
-            String masterPassword = getProperty(PropertyKey.MASTER_PASSWORD.toString());
+            String masterPassword = getProperty(PropertyKey.MASTER_PASSWORD);
             return masterPassword == null ? null : masterPassword.toCharArray();
         }
 
         public String getServer() {
-            return getProperty(PropertyKey.SERVER.toString());
+            return getProperty(PropertyKey.SERVER);
         }
 
         public String getSID() {
-            return getProperty(PropertyKey.SID.toString());
+            return getProperty(PropertyKey.SID);
         }
 
         public boolean isAllowStoreSID() {
-            return Boolean.parseBoolean(getProperty(PropertyKey.ALLOW_STORE_SID.toString()));
+            return Boolean.parseBoolean(getProperty(PropertyKey.ALLOW_STORE_SID));
         }
 
-        public boolean isPossibleSIDLogin() {
+        public boolean shouldSIDLogin() {
             return !Strings.isEmpty(getSID()) && !Strings.isEmpty(getServer());
         }
 
         public void setServer(String server) {
-            setProperty(PropertyKey.SERVER.toString(), server);
+            setProperty(PropertyKey.SERVER, server);
         }
 
         public void setSID(String sid) {
-            setProperty(PropertyKey.SID.toString(), sid);
+            setProperty(PropertyKey.SID, sid);
         }
 
         public void updateLoginFile() {
             try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(path), StandardCharsets.UTF_8)) {
-                store(writer, null);
+                prop.store(writer, null);
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/com/github/manolo8/darkbot/utils/StartupParams.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/StartupParams.java
@@ -3,10 +3,14 @@ package com.github.manolo8.darkbot.utils;
 import eu.darkbot.api.API;
 import eu.darkbot.util.function.ThrowingFunction;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -61,9 +65,28 @@ public class StartupParams implements API.Singleton {
     }
 
     public enum PropertyKey {
-        USERNAME, PASSWORD, MASTER_PASSWORD
+        USERNAME, PASSWORD, MASTER_PASSWORD, SERVER, SID;
+        @Override
+        public String toString() {
+            return this.name().toLowerCase(Locale.ROOT);
+        }
     }
 
+    public void updateSidAndServer(String sid, String server) {
+        Properties login = (Properties) startupParams.get(LaunchArg.LOGIN);
+        Path path = new File(login.getProperty("SourceFile")).toPath();
+        login.setProperty(PropertyKey.SERVER.toString(), server);
+        login.setProperty(PropertyKey.SID.toString(), sid);
+
+        try {
+            Files.write(path, Arrays.stream(PropertyKey.values())
+                    .filter(x -> login.containsKey(x.toString()))
+                    .map(x -> x + "=" + getAutoLoginValue(x))
+                    .collect(Collectors.toList()), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
     private final Map<LaunchArg, Object> startupParams = new HashMap<>();
 
@@ -87,6 +110,7 @@ public class StartupParams implements API.Singleton {
     /* Auto login */
     private static Properties loadLoginProperties(String path) throws IOException {
         Properties p = new Properties();
+        p.setProperty("SourceFile", path);
         try (InputStreamReader reader = new InputStreamReader(new FileInputStream(path), StandardCharsets.UTF_8)) {
             p.load(reader);
         }
@@ -96,12 +120,16 @@ public class StartupParams implements API.Singleton {
 
     public String getAutoLoginValue(PropertyKey key) {
         Properties p = (Properties) startupParams.get(LaunchArg.LOGIN);
-        return p.getProperty(key.name().toLowerCase(Locale.ROOT));
+        return p.getProperty(key.toString());
     }
 
     public char[] getAutoLoginMasterPassword() {
         String masterPassword = getAutoLoginValue(PropertyKey.MASTER_PASSWORD);
         return masterPassword == null ? null : masterPassword.toCharArray();
+    }
+
+    public void clearAutoLoginProp(PropertyKey key) {
+        ((Properties) startupParams.get(LaunchArg.LOGIN)).setProperty(key.toString(), "");
     }
 
     /* Other params */

--- a/src/main/java/com/github/manolo8/darkbot/utils/StartupParams.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/StartupParams.java
@@ -90,7 +90,7 @@ public class StartupParams implements API.Singleton {
         }
     }
 
-    public AutoLoginProps getAutoLoginProps(){
+    public AutoLoginProps getAutoLoginProps() {
         return (AutoLoginProps) startupParams.getOrDefault(LaunchArg.LOGIN, null);
     }
 

--- a/src/main/java/com/github/manolo8/darkbot/utils/login/LoginUtils.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/login/LoginUtils.java
@@ -26,6 +26,7 @@ import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -83,11 +84,10 @@ public class LoginUtils {
         LoginData loginData = new LoginData();
         loginData.setCredentials(username, password);
 
-        System.out.println("Attempt of auto logging using " + (isSidLogin?"server/SID":"login/password") + " in (1/2)");
-        if (isSidLogin) loginData.setSid(sid, server + ".darkorbit.com");
-        else usernameLogin(loginData);
-
+        System.out.println("Auto logging in using " + (isSidLogin ? "server & SID" : "user & password") + " (1/2)");
         try {
+            if (isSidLogin) loginData.setSid(sid, server + ".darkorbit.com");
+            else usernameLogin(loginData);
             System.out.println("Loading spacemap (2/2)");
             findPreloader(loginData);
         } catch (IOException e) {
@@ -95,7 +95,7 @@ public class LoginUtils {
             e.printStackTrace();
         } catch (WrongCredentialsException e) {
             if (isSidLogin) {
-                System.err.println("Expired SID in login properties file");
+                System.err.println("Expired SID in login properties file, attempting re-connect with user & pass");
                 params.setAutoLoginProp(StartupParams.PropertyKey.SID, "");
                 return performAutoLogin(params);
             }
@@ -107,7 +107,7 @@ public class LoginUtils {
             System.exit(-1);
         }
 
-        if (!Strings.isEmpty(server) && !isSidLogin) {
+        if (!isSidLogin && Boolean.parseBoolean(params.getAutoLoginValue(StartupParams.PropertyKey.ALLOW_STORE_SID))) {
             params.setAutoLoginProp(StartupParams.PropertyKey.SERVER, loginData.getUrl().split("\\.")[0]);
             params.setAutoLoginProp(StartupParams.PropertyKey.SID, loginData.getSid());
             params.updateLoginFile();

--- a/src/main/java/com/github/manolo8/darkbot/utils/login/LoginUtils.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/login/LoginUtils.java
@@ -26,7 +26,6 @@ import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/main/java/com/github/manolo8/darkbot/utils/login/LoginUtils.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/login/LoginUtils.java
@@ -64,14 +64,14 @@ public class LoginUtils {
 
     public static LoginData performAutoLogin(StartupParams.AutoLoginProps params) {
         String password = params.getPassword();
-        if (!params.isPossibleSIDLogin() && params.getUsername() != null && Strings.isEmpty(password)) {
+        if (!params.shouldSIDLogin() && params.getUsername() != null && Strings.isEmpty(password)) {
             password = getPassword(params.getUsername(), params.getMasterPassword());
 
             if (password == null)
                 System.err.println("Password for user couldn't be retrieved. Check that the user exists and master password is correct.");
         }
 
-        if (!params.isPossibleSIDLogin() && (params.getUsername() == null || Strings.isEmpty(password))) {
+        if (!params.shouldSIDLogin() && (params.getUsername() == null || Strings.isEmpty(password))) {
             System.err.println("Credentials file requires username & either a password or a master password, or/and server & sid");
             System.exit(-1);
         }
@@ -79,9 +79,9 @@ public class LoginUtils {
         LoginData loginData = new LoginData();
         loginData.setCredentials(params.getUsername(), password);
 
-        System.out.println("Auto logging in using " + (params.isPossibleSIDLogin() ? "server & SID" : "user & password") + " (1/2)");
+        System.out.println("Auto logging in using " + (params.shouldSIDLogin() ? "server & SID" : "user & password") + " (1/2)");
         try {
-            if (params.isPossibleSIDLogin()) loginData.setSid(params.getSID(), params.getServer() + ".darkorbit.com");
+            if (params.shouldSIDLogin()) loginData.setSid(params.getSID(), params.getServer() + ".darkorbit.com");
             else usernameLogin(loginData);
             System.out.println("Loading spacemap (2/2)");
             findPreloader(loginData);
@@ -89,7 +89,7 @@ public class LoginUtils {
             System.err.println("IOException trying to perform auto login, servers may be down");
             e.printStackTrace();
         } catch (WrongCredentialsException e) {
-            if (params.isPossibleSIDLogin()) {
+            if (params.shouldSIDLogin()) {
                 System.err.println("Expired SID in login properties file, attempting re-connect with user & pass");
                 params.setSID("");
                 return performAutoLogin(params);
@@ -102,7 +102,7 @@ public class LoginUtils {
             System.exit(-1);
         }
 
-        if (!params.isPossibleSIDLogin() && params.isAllowStoreSID()) {
+        if (!params.shouldSIDLogin() && params.isAllowStoreSID()) {
             params.setServer(loginData.getUrl().split("\\.")[0]);
             params.setSID(loginData.getSid());
             params.updateLoginFile();


### PR DESCRIPTION
Was customized logic of autologin.
If `sid` and `server` is present in prop file than for first attempt of login will used this credentials.
If previous step is unsuccessful and exist `login/password` for default authorization than this credential will used for attempts.
If default authorization was successful and `server` present in prop file than new SID will saved to prop file.