### PR TITLE
avoid plugin already in use by other bugged java process

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/gui/MainGui.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/MainGui.java
@@ -15,6 +15,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.io.IOException;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -68,7 +69,14 @@ public class MainGui extends JFrame {
             });
         }
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> main.configManager.saveConfig()));
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                main.pluginHandler.PLUGIN_CLASS_LOADER.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            main.configManager.saveConfig();
+        }));
     }
 
     private void setComponentPosition() {


### PR DESCRIPTION
Sometimes when the java process closes, it does not actually release/unlock the files for the plugins, so later when a new bot instance runs it is prevented from replacing those plugin files (eg: when trying to update plugins). If that happens, you're left with needing to restart your PC (or killing the process) before being able to update the plugins.

This pr attempts to fix it by making sure the class loader is closed on shutdown