### PR TITLE
Optimize trail generation to avoid garbage collection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,8 +45,8 @@ dependencies {
     val apiVersion = "0.6.0"
 
     // use this if you want to use local(mavenLocal) darkbot API
-    api("eu.darkbot", "darkbot-impl", apiVersion)
-    //api("eu.darkbot.DarkBotAPI", "darkbot-impl", apiVersion)
+    //api("eu.darkbot", "darkbot-impl", apiVersion)
+    api("eu.darkbot.DarkBotAPI", "darkbot-impl", apiVersion)
     api("com.google.code.gson", "gson", "2.8.9")
     api("com.miglayout", "miglayout", "3.7.4")
     api("org.jetbrains", "annotations", "23.0.0")
@@ -55,7 +55,7 @@ dependencies {
     implementation("org.jgrapht", "jgrapht-core", "1.3.0")
     implementation("org.mvel", "mvel2", "2.4.4.Final")
 
-    testImplementation("junit:junit:4.13.1")
+    testImplementation("junit:junit:4.13.2")
     testCompileOnly("org.jgrapht", "jgrapht-io", "1.3.0")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation("org.jgrapht", "jgrapht-core", "1.3.0")
     implementation("org.mvel", "mvel2", "2.4.4.Final")
 
+    testImplementation("junit:junit:4.13.1")
     testCompileOnly("org.jgrapht", "jgrapht-io", "1.3.0")
 }
 

--- a/src/main/java/com/github/manolo8/darkbot/gui/drawables/TrailDrawer.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/drawables/TrailDrawer.java
@@ -48,7 +48,7 @@ public class TrailDrawer implements Drawable {
             positions.add().init(last, last.setTo(hero));
         }
 
-        long removeBefore = System.currentTimeMillis() - trailLength.getValue() * 1000L;
+        long removeBefore = System.currentTimeMillis() - (trailLength.getValue() * 1000L);
         while (!positions.isEmpty()) {
             Line line = positions.get();
             if (line.getTime() > removeBefore) break;

--- a/src/main/java/com/github/manolo8/darkbot/gui/drawables/TrailDrawer.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/drawables/TrailDrawer.java
@@ -44,7 +44,7 @@ public class TrailDrawer implements Drawable {
 
         if (distance > 500) {
             last.setTo(hero);
-        } else if (distance > 100) {
+        } else if (distance > 10) {
             positions.add().init(last, last.setTo(hero));
         }
 

--- a/src/main/java/com/github/manolo8/darkbot/gui/drawables/TrailDrawer.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/drawables/TrailDrawer.java
@@ -2,6 +2,7 @@ package com.github.manolo8.darkbot.gui.drawables;
 
 import com.github.manolo8.darkbot.config.ColorScheme;
 import com.github.manolo8.darkbot.gui.trail.Line;
+import com.github.manolo8.darkbot.utils.data.RecyclingQueue;
 import eu.darkbot.api.config.ConfigSetting;
 import eu.darkbot.api.extensions.Draw;
 import eu.darkbot.api.extensions.Drawable;
@@ -15,7 +16,6 @@ import eu.darkbot.api.managers.HeroAPI;
 import java.awt.*;
 import java.util.Collection;
 import java.util.List;
-import java.util.TreeMap;
 
 @Feature(name = "Trail Drawer", description = "Draws hero's trail")
 @Draw(value = Draw.Stage.HERO_TRAIL, attach = Draw.Attach.REPLACE)
@@ -23,9 +23,9 @@ public class TrailDrawer implements Drawable {
 
     private final ConfigSetting<Integer> trailLength;
     private final ConfigSetting<ColorScheme> cs;
-    private final TreeMap<Long, Line> positions = new TreeMap<>();
+    private final RecyclingQueue<Line> positions = new RecyclingQueue<>(Line::new);
     private final HeroAPI hero;
-    private Location last = Location.of(0, 0);
+    private final Location last = Location.of(0, 0);
 
     public TrailDrawer(HeroAPI hero, ConfigAPI config) {
         this.hero = hero;
@@ -43,17 +43,23 @@ public class TrailDrawer implements Drawable {
         double distance = last.distanceTo(hero);
 
         if (distance > 500) {
-            last = hero.getLocationInfo().copy();
+            last.setTo(hero);
         } else if (distance > 100) {
-            positions.put(System.currentTimeMillis(), new Line(last, last = hero.getLocationInfo().copy()));
+            positions.add().init(last, last.setTo(hero));
         }
-        positions.headMap(System.currentTimeMillis() - trailLength.getValue() * 1000L).clear();
+
+        long removeBefore = System.currentTimeMillis() - trailLength.getValue() * 1000L;
+        while (!positions.isEmpty()) {
+            Line line = positions.get();
+            if (line.getTime() > removeBefore) break;
+            positions.remove();
+        }
 
         if (positions.isEmpty()) return;
 
         Stroke stroke = mg.getGraphics2D().getStroke();
         mg.getGraphics2D().setStroke(new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_ROUND));
-        List<List<Location>> paths = Line.getSmoothedPaths(positions.values());
+        List<List<Location>> paths = Line.getSmoothedPaths(positions);
 
         double max = paths.stream().mapToInt(Collection::size).sum() / 255d, curr = 0;
         for (List<Location> points : paths) {

--- a/src/main/java/com/github/manolo8/darkbot/gui/trail/Line.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/trail/Line.java
@@ -60,8 +60,8 @@ public class Line {
         Line last = null;
 
         for (Line line : lines) {
-            if (last == null || last.to != line.from) {
-                paths.add(current = new ArrayList<>(lines.size()));
+            if (last == null || last.to.equals(line.from)) {
+                paths.add(current = new ArrayList<>(lines.size() + 1));
                 current.add(line.getFrom());
             }
             last = line;

--- a/src/main/java/com/github/manolo8/darkbot/gui/trail/Line.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/trail/Line.java
@@ -1,45 +1,59 @@
 package com.github.manolo8.darkbot.gui.trail;
 
+import com.github.manolo8.darkbot.utils.data.SizedIterable;
+import eu.darkbot.api.game.other.Locatable;
 import eu.darkbot.api.game.other.Location;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
 /**
  * A method to smooth a hand-drawn line based on the McMaster
- * line smoothing algorithm
- *
+ * line smoothing algorithm.
+ * <br>
  * Heavily modified version, based on the implementation by:
  * @author Derek Springer
- * @link https://12inchpianist.com/2010/07/30/line-smoothing-in-java/
+ * @link <a href="https://12inchpianist.com/2010/07/30/line-smoothing-in-java/">...</a>
  */
 public class Line {
+    private long time;
     private final Location from, to;
-    private Location fromCopy, toCopy;
+    private final Location fromCopy, toCopy;
 
-    public Line(Location from, Location to) {
-        this.from = from;
-        this.to = to;
+    public Line() {
+        this.from = Location.of(0, 0);
+        this.to = Location.of(0, 0);
+        this.fromCopy = Location.of(0, 0);
+        this.toCopy = Location.of(0, 0);
+    }
+
+    public void init(Locatable from, Locatable to) {
+        this.time = System.currentTimeMillis();
+        this.from.setTo(from);
+        this.to.setTo(to);
+    }
+
+    public long getTime() {
+        return time;
     }
 
     private Location getFrom() {
-        return fromCopy == null ? fromCopy = from.copy() : fromCopy.setTo(from.getX(), from.getY());
+        return fromCopy.setTo(from.getX(), from.getY());
     }
 
     private Location getTo() {
-        return toCopy == null ? toCopy = to.copy() : toCopy.setTo(to.getX(), to.getY());
+        return toCopy.setTo(to.getX(), to.getY());
     }
 
-    public static List<List<Location>> getSmoothedPaths(Collection<Line> lines) {
+    public static List<List<Location>> getSmoothedPaths(SizedIterable<Line> lines) {
         return getPaths(lines).stream().map(Line::smoothPath).collect(Collectors.toList());
     }
 
     /**
      * Split a single list of lines in N paths
      */
-    private static List<List<Location>> getPaths(Collection<Line> lines) {
+    private static List<List<Location>> getPaths(SizedIterable<Line> lines) {
         List<List<Location>> paths = new ArrayList<>();
 
         List<Location> current = null;
@@ -47,7 +61,7 @@ public class Line {
 
         for (Line line : lines) {
             if (last == null || last.to != line.from) {
-                paths.add(current = new ArrayList<>());
+                paths.add(current = new ArrayList<>(lines.size()));
                 current.add(line.getFrom());
             }
             last = line;

--- a/src/main/java/com/github/manolo8/darkbot/utils/data/RecyclingQueue.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/data/RecyclingQueue.java
@@ -56,7 +56,13 @@ public class RecyclingQueue<T> implements SizedIterable<T> {
     }
 
     private Node getNode() {
-        if (original == null || original == last) return new Node();
+        // Cannot recycle, gotta make a new node
+        if (original == first) {
+            Node newNode = new Node();
+            // First initialization ever, set the original
+            if (original == null) original = newNode;
+            return newNode;
+        }
 
         Node node = original;
         original = node.next;
@@ -66,7 +72,7 @@ public class RecyclingQueue<T> implements SizedIterable<T> {
 
     public T add() {
         Node newNode = getNode();
-        if (first == null) original = last = first = newNode;
+        if (first == null) last = first = newNode;
         else last = last.next = newNode;
         size++;
         return last.value;

--- a/src/main/java/com/github/manolo8/darkbot/utils/data/RecyclingQueue.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/data/RecyclingQueue.java
@@ -1,0 +1,154 @@
+package com.github.manolo8.darkbot.utils.data;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Supplier;
+
+/**
+ * Implements a recycling FIFO queue, aimed at minimizing memory allocations.
+ * It does NOT implement Collection or Queue because objects are always recycled for performance reasons.
+ * <br>
+ * How it works:
+ * There are 3 pointers, original, first and last
+ * As you {@link #add} elements, they are added after last, last starts pointing to the newly added node.
+ * As you {@link #remove} elements, first moves over, however original is not moved.
+ * When you {@link #add}, the newly added node can be recycled from original, in which case, it moves over.
+ * <br>
+ * Example:
+ * (original) A -> B -> (first) C -> D -> E -> F -> (last) G
+ * After calling {@link #add}:
+ * (original) B -> (first) C -> D -> E -> F -> G -> (last) A
+ * Notice how A was recycled.
+ * <br>
+ * This allows for automatic object node & object pooling, they are assumed to be mutable.
+ *
+ * @param <T> The type. Must be mutable
+ */
+public class RecyclingQueue<T> implements SizedIterable<T> {
+
+    /**
+     * Max amount (in percentage) of extra objects to keep for reusing later.
+     * A factor of 0 would mean keep 0% extra objects. (Don't do this.)
+     * A factor of 0.5 means keep 50% of size, if size is 10, you can keep up to 5 extra unused objects.
+     */
+    private static final float RECYCLE_FACTOR = 0.5f;
+
+    /**
+     * Minimum amount of objects to always keep to recycle.
+     * Mainly exists so that even if size is 0 you don't throw away all objects.
+     */
+    private static final int MIN_RECYCLE = 10;
+
+    private final Supplier<T> supplier;
+
+    private Node original, first, last;
+    private int size;
+    private int allocatedSize;
+
+    /**
+     * Create a recycling queue
+     * @param supplier The supplier to create new objects
+     */
+    public RecyclingQueue(Supplier<T> supplier) {
+        this.supplier = supplier;
+    }
+
+    private Node getNode() {
+        if (original == null || original == last) return new Node();
+
+        Node node = original;
+        original = node.next;
+        node.next = null;
+        return node;
+    }
+
+    public T add() {
+        Node newNode = getNode();
+        if (first == null) original = last = first = newNode;
+        else last = last.next = newNode;
+        size++;
+        return last.value;
+    }
+
+    public void remove() {
+        if (first == null)
+            throw new NoSuchElementException();
+        first = first.next;
+
+        // Whole list has been cleared
+        if (first == null) last = null;
+
+        size--;
+        purge();
+    }
+
+    public T get() {
+        if (first == null)
+            throw new NoSuchElementException();
+
+        return first.value;
+    }
+
+    // Clean up excess nodes that are only saved to avoid future allocations
+    private void purge() {
+        int maxTotal = size + Math.max(MIN_RECYCLE, Math.round(size * RECYCLE_FACTOR));
+        assert maxTotal > size;
+        while (allocatedSize > maxTotal) {
+            assert original != null;
+            original = original.next;
+            allocatedSize--;
+        }
+    }
+
+    public boolean isEmpty() {
+        return first == null;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    @NotNull
+    @Override
+    public Iterator<T> iterator() {
+        return new QueueIterator();
+    }
+
+    private class Node {
+        private Node next;
+        private final T value = supplier.get();
+
+        public Node() {
+            allocatedSize++;
+        }
+    }
+
+    private class QueueIterator implements Iterator<T> {
+        private Node next;
+
+        QueueIterator() {
+            next = first;
+        }
+
+        public boolean hasNext() {
+            return next != null;
+        }
+
+        public T next() {
+            if (!hasNext())
+                throw new NoSuchElementException();
+
+            Node current = this.next;
+            this.next = current.next;
+            return current.value;
+        }
+
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+}

--- a/src/main/java/com/github/manolo8/darkbot/utils/data/RecyclingQueue.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/data/RecyclingQueue.java
@@ -56,13 +56,8 @@ public class RecyclingQueue<T> implements SizedIterable<T> {
     }
 
     private Node getNode() {
-        // Cannot recycle, gotta make a new node
-        if (original == first) {
-            Node newNode = new Node();
-            // First initialization ever, set the original
-            if (original == null) original = newNode;
-            return newNode;
-        }
+        // Cannot recycle, either both are null, or nothing left to recycle
+        if (original == first) return new Node();
 
         Node node = original;
         original = node.next;
@@ -72,8 +67,12 @@ public class RecyclingQueue<T> implements SizedIterable<T> {
 
     public T add() {
         Node newNode = getNode();
-        if (first == null) last = first = newNode;
-        else last = last.next = newNode;
+        if (first == null) {
+            first = last = newNode;
+            if (original == null) original = first;
+        } else {
+            last = last.next = newNode;
+        }
         size++;
         return last.value;
     }
@@ -132,11 +131,7 @@ public class RecyclingQueue<T> implements SizedIterable<T> {
     }
 
     private class QueueIterator implements Iterator<T> {
-        private Node next;
-
-        QueueIterator() {
-            next = first;
-        }
+        private Node next = first;
 
         public boolean hasNext() {
             return next != null;

--- a/src/main/java/com/github/manolo8/darkbot/utils/data/RecyclingQueue.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/data/RecyclingQueue.java
@@ -68,6 +68,9 @@ public class RecyclingQueue<T> implements SizedIterable<T> {
     public T add() {
         Node newNode = getNode();
         if (first == null) {
+            // When list becomes empty (first = null), last maintains the last node
+            // Make sure the previous last node connects to the new head
+            if (last != null) last.next = newNode;
             first = last = newNode;
             if (original == null) original = first;
         } else {
@@ -81,10 +84,6 @@ public class RecyclingQueue<T> implements SizedIterable<T> {
         if (first == null)
             throw new NoSuchElementException();
         first = first.next;
-
-        // Whole list has been cleared
-        if (first == null) last = null;
-
         size--;
         purge();
     }

--- a/src/main/java/com/github/manolo8/darkbot/utils/data/SizedIterable.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/data/SizedIterable.java
@@ -1,0 +1,5 @@
+package com.github.manolo8.darkbot.utils.data;
+
+public interface SizedIterable<T> extends Iterable<T> {
+    int size();
+}

--- a/src/test/java/eu/darkbot/util/RecyclingQueueTest.java
+++ b/src/test/java/eu/darkbot/util/RecyclingQueueTest.java
@@ -16,23 +16,26 @@ public class RecyclingQueueTest {
         Assert.assertThrows(NoSuchElementException.class, queue::remove);
 
         queue.add().val = 1;
-        Assert.assertEquals(1, queue.size());
+        queue.add().val = 2;
+        Assert.assertEquals(2, queue.size());
 
+        queue.remove();
         queue.remove();
         Assert.assertEquals(0, queue.size());
         Assert.assertThrows(NoSuchElementException.class, queue::get);
         Assert.assertThrows(NoSuchElementException.class, queue::remove);
 
-        // Ensure it recycles the value
+        // Ensure it recycles the values
         Assert.assertEquals(1, queue.add().val);
+        Assert.assertEquals(2, queue.add().val);
 
-        for (int i = 2; i <= 10; i++)
-            queue.add().val = i;
-        Assert.assertEquals(10, queue.size());
+        // Assert a new node will be fresh
+        Assert.assertEquals(0, queue.add().val);
+
+        Assert.assertEquals(3, queue.size());
 
         queue.remove();
-        Assert.assertEquals(9, queue.size());
-
+        Assert.assertEquals(2, queue.size());
 
         // Ensure it recycles the value
         Assert.assertEquals(1, queue.add().val);

--- a/src/test/java/eu/darkbot/util/RecyclingQueueTest.java
+++ b/src/test/java/eu/darkbot/util/RecyclingQueueTest.java
@@ -1,0 +1,46 @@
+package eu.darkbot.util;
+
+import com.github.manolo8.darkbot.utils.data.RecyclingQueue;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+
+public class RecyclingQueueTest {
+
+    @Test
+    public void testRecyclingQueue() {
+        RecyclingQueue<Value> queue = new RecyclingQueue<>(Value::new);
+
+        Assert.assertThrows(NoSuchElementException.class, queue::get);
+        Assert.assertThrows(NoSuchElementException.class, queue::remove);
+
+        queue.add().val = 1;
+        Assert.assertEquals(1, queue.size());
+
+        queue.remove();
+        Assert.assertEquals(0, queue.size());
+        Assert.assertThrows(NoSuchElementException.class, queue::get);
+        Assert.assertThrows(NoSuchElementException.class, queue::remove);
+
+        // Ensure it recycles the value
+        Assert.assertEquals(1, queue.add().val);
+
+        for (int i = 2; i <= 10; i++)
+            queue.add().val = i;
+        Assert.assertEquals(10, queue.size());
+
+        queue.remove();
+        Assert.assertEquals(9, queue.size());
+
+
+        // Ensure it recycles the value
+        Assert.assertEquals(1, queue.add().val);
+    }
+
+
+    private static class Value {
+        int val;
+    }
+
+}


### PR DESCRIPTION
Currently trails on the bot are generated by saving a TreeMap of Lines, they're added as needed, and the entries older than X time (configured) are pruned. This generates an unnecessarily large amount of allocations and deletions.

This PR implements a new data structure, a "recycling queue". It consists of a singly-linked list, with two heads and one tail, which works strictly in FIFO mode. You may only add elements at the back, and you may only retrieve/remove elements from the front.

When adding elements (at the back) the tail node gets a new next node, and tail starts pointing to the new node
When removing elements (from the front) the head pointer starts pointing to the next node
The "original head" pointer is used to keep strong a reference to the "removed" elements, as what essentially is a second queue, both sharing the same chain. When a new element is requested (to be added at the back), the "original head" is checked first, if it has leftover elements, then original head moves forwards (removes the element from that logical second queue) and the node is added at the back. If the "original head" reaches the head, it cannot advance anymore and instead allocates a new node to supply the demand for a new node.

Aditonally, when removing elements if the "overall size" (sum of all allocated nodes) far exceeds the amount of nodes actually in use, then the "original head" will be moved over to deallocate some of the objects. There's a ratio of a maximum of 50% extra buffer (eg: if size is 1000, you may only keep up to 500 extra as buffer).

This accomplishes a solution similar to one of a circular buffer, but of dynamic size and implemented as a single-linked list instead of an array (which is more expensive to grow/shrink).