### PR TITLE
show icons in dialogs

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/Bot.java
+++ b/src/main/java/com/github/manolo8/darkbot/Bot.java
@@ -120,8 +120,11 @@ public class Bot {
         // support windows 7 too
         @Override
         public boolean getSupportsWindowDecorations() {
-            return !SystemInfo.isProjector && !SystemInfo.isWebswing && !SystemInfo.isWinPE
-                    && (!SystemInfo.isWindows_10_orLater || !FlatNativeWindowBorder.isSupported());
+            if (SystemInfo.isProjector || SystemInfo.isWebswing || SystemInfo.isWinPE)
+                return false;
+
+            // return true if native border isn't supported
+            return !(SystemInfo.isWindows_10_orLater && FlatNativeWindowBorder.isSupported());
         }
     }
 }

--- a/src/main/java/com/github/manolo8/darkbot/Bot.java
+++ b/src/main/java/com/github/manolo8/darkbot/Bot.java
@@ -39,17 +39,16 @@ public class Bot {
 
             // Set no padding when icon is removed
             UIManager.put("TitlePane.noIconLeftGap", 0);
+            UIManager.put("OptionPane.showIcon", true);
 
-            if (SystemInfo.isLinux ) {
-                // enable custom window decorations
-                JFrame.setDefaultLookAndFeelDecorated( true );
-                JDialog.setDefaultLookAndFeelDecorated( true );
-            }
+            // enable custom window decorations - need on w7 also
+            JFrame.setDefaultLookAndFeelDecorated(true);
+            JDialog.setDefaultLookAndFeelDecorated(true);
 
             // Load necessary native libraries
             FlatNativeWindowBorder.isSupported();
 
-            UIManager.setLookAndFeel(new FlatDarkLaf());
+            UIManager.setLookAndFeel(new DarkLaf());
             UIManager.put("Button.arc", 0);
             UIManager.put("Component.arc", 0);
             UIManager.put("Button.default.boldText", false);
@@ -116,4 +115,13 @@ public class Bot {
         });
     }
 
+    public static class DarkLaf extends FlatDarkLaf {
+
+        // support windows 7 too
+        @Override
+        public boolean getSupportsWindowDecorations() {
+            return !SystemInfo.isProjector && !SystemInfo.isWebswing && !SystemInfo.isWinPE
+                    && (!SystemInfo.isWindows_10_orLater || !FlatNativeWindowBorder.isSupported());
+        }
+    }
 }

--- a/src/main/java/com/github/manolo8/darkbot/gui/ConfigGui.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/ConfigGui.java
@@ -41,6 +41,8 @@ public class ConfigGui extends JFrame {
         super("DarkBot Configuration");
         getRootPane().putClientProperty(FlatClientProperties.TITLE_BAR_SHOW_ICON, false);
         getRootPane().putClientProperty(FlatClientProperties.TITLE_BAR_SHOW_TITLE, false);
+        //getRootPane().putClientProperty(FlatClientProperties.TITLE_BAR_SHOW_MAXIMIZE, false);
+        //getRootPane().putClientProperty(FlatClientProperties.TITLE_BAR_SHOW_ICONIFFY, false);
 
         this.main = main;
 


### PR DESCRIPTION
show icons in dialogs
force using flat title bar if native border is not supported (tested on w7)