### PR TITLE
Better solve circular dependency on dropdown handlers

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/config/ConfigHandler.java
+++ b/src/main/java/com/github/manolo8/darkbot/config/ConfigHandler.java
@@ -24,7 +24,7 @@ public class ConfigHandler implements ConfigAPI, Listener {
     private final ConfigManager loader;
     private final ConfigBuilder builder;
 
-    private ConfigSetting.Parent<Config> configuration;
+    private final ConfigSetting.Parent<Config> configuration;
 
     public ConfigHandler(PluginAPI api,
                          ConfigManager loader,
@@ -32,13 +32,12 @@ public class ConfigHandler implements ConfigAPI, Listener {
         this.pluginAPI = api;
         this.loader = loader;
         this.builder = builder;
+        this.configuration = builder.of(Config.class, "Configuration", null);
+        this.configuration.setValue(loader.getConfig());
     }
 
     @Inject
     public void init() {
-        this.configuration = builder.of(Config.class, "Configuration", null);
-        this.configuration.setValue(loader.getConfig());
-
         ConfigEntity.INSTANCE = pluginAPI.requireInstance(ConfigEntity.class);
     }
 

--- a/src/main/java/com/github/manolo8/darkbot/config/tree/handlers/LazyInitHandler.java
+++ b/src/main/java/com/github/manolo8/darkbot/config/tree/handlers/LazyInitHandler.java
@@ -1,0 +1,40 @@
+package com.github.manolo8.darkbot.config.tree.handlers;
+
+import eu.darkbot.impl.config.DefaultHandler;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class LazyInitHandler<T> extends DefaultHandler<T> {
+
+    protected final Map<String, Supplier<?>> lazyMetadata = new HashMap<>();
+
+    public LazyInitHandler() {
+        this(null);
+    }
+
+    public LazyInitHandler(@Nullable Field field) {
+        super(field);
+    }
+
+    private void check(String key) {
+        if (lazyMetadata.isEmpty()) return;
+        Supplier<?> supplier = lazyMetadata.remove(key);
+        if (supplier != null) metadata.put(key, supplier.get());
+    }
+
+    @Override
+    public <V> @Nullable V getMetadata(String key) {
+        check(key);
+        return super.getMetadata(key);
+    }
+
+    @Override
+    public <V> @Nullable V getOrCreateMetadata(String key, Supplier<V> builder) {
+        check(key);
+        return super.getOrCreateMetadata(key, builder);
+    }
+}

--- a/src/main/java/com/github/manolo8/darkbot/utils/data/SingletonSupplier.java
+++ b/src/main/java/com/github/manolo8/darkbot/utils/data/SingletonSupplier.java
@@ -1,0 +1,38 @@
+package com.github.manolo8.darkbot.utils.data;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Supplier;
+
+public class SingletonSupplier<T> implements Supplier<T> {
+
+    private Supplier<T> supplier;
+    private T value;
+
+    public static <T> Supplier<T> of(Supplier<T> supplier) {
+        if (supplier instanceof SingletonSupplier) return supplier;
+        return new SingletonSupplier<>(supplier);
+    }
+
+    public static <T> Supplier<T> resolved(T value) {
+        return new SingletonSupplier<>(value);
+    }
+
+    private SingletonSupplier(@NotNull Supplier<T> supplier) {
+        this.supplier = supplier;
+        this.value = null;
+    }
+
+    private SingletonSupplier(T value) {
+        this.supplier = null;
+        this.value = value;
+    }
+
+    public T get() {
+        if (supplier != null) {
+            value = supplier.get();
+            supplier = null;
+        }
+        return value;
+    }
+}


### PR DESCRIPTION
Currently there's a circular dependency from:

ConfigAPI -> ConfigBuilder  -> DropdownHandler#of -> PetGears -> PetManager -> MapManager -> ConfigAPI

But what is this supposed to mean?

What it means is:
  - To build the config, you need to build the config tree
  - To build the config tree, each config setting has a ValueHandler, in this case, the DropdownHandler
  - To build the DropdownHandler, you have to build the Dropdown, in this case, PetGears
  - PetGears requires PetManager to function (it gets its list of gears to show from there)
  - PetManager is the actual pet entity, it's a god-like entity, and requires lots of things, like MapManager
  - MapManager needs config api too
  
The last 2 steps are not really all that relevant, yes, PetManager is a big entity and so, something is bound to break from requiring config api, if it wasn't MapManager it'd be something else. 
What's changed here, is now PetGearls will not be built at the same time as the rest of these, and will instead be deferred to be built when actually needed (when the UI wants to show the list), breaking the circular dependency.

Note for the future: if any other kind of handler is requiring arbitrary objects being injected, we should make sure they're always deferred to Editor build time. TableHandler &  TableEditor were already doing this, although not intentionally.