### PR TITLE
Turning AVOID_RADIATION off by default

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/config/Config.java
+++ b/src/main/java/com/github/manolo8/darkbot/config/Config.java
@@ -198,7 +198,7 @@ public class Config implements eu.darkbot.api.config.legacy.Config {
         public @Option @Visibility(Level.INTERMEDIATE) boolean LOG_CHAT = false;
         public @Option @Visibility(Level.INTERMEDIATE) boolean LOG_DEATHS = false;
         public @Option @Visibility(Level.INTERMEDIATE) boolean AVOID_MINES = true;
-        public @Option @Visibility(Level.INTERMEDIATE) boolean AVOID_RADIATION = true;
+        public @Option @Visibility(Level.INTERMEDIATE) boolean AVOID_RADIATION = false;
         public @Option @Visibility(Level.INTERMEDIATE) boolean USERNAME_ON_TITLE = false;
         public @Option @Visibility(Level.ADVANCED) boolean AUTO_REFINE = false;
     }


### PR DESCRIPTION
This should be off by default as the description already says... ''use only if you are well aware of what you are doing''