### PR TITLE
use group member array size

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/core/manager/GroupManager.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/manager/GroupManager.java
@@ -201,7 +201,6 @@ public class GroupManager extends Gui implements GroupAPI {
             inviteTimeout.put(member.username, System.currentTimeMillis() + 30_000);
             runClicks(getPoint(GroupAction.REMOVE), getMemberPoint(idx));
         };
-
     }
 
     public void kick(GroupMember member) {
@@ -270,11 +269,11 @@ public class GroupManager extends Gui implements GroupAPI {
 
     @Override
     public boolean canInvite() {
-        return (!group.isValid() || group.isOpen || group.isLeader) && invites.size() + group.size < 8;
+        return (!group.isValid() || group.isOpen || group.isLeader) && invites.size() + group.members.size() < 7;
     }
 
     private int getGroupHeight() {
-        return (Math.max(0, group.size - 1) * MEMBER_HEIGHT) +
+        return (Math.max(0, group.members.size()) * MEMBER_HEIGHT) +
                 (invites.size() * BUTTON_HEIGHT) +
                 ((group.isValid() && (group.isOpen || group.isLeader)) ? BUTTON_HEIGHT : 0);
     }
@@ -314,7 +313,7 @@ public class GroupManager extends Gui implements GroupAPI {
 
     @Override
     public int getSize() {
-        return group.size;
+        return group.members.size() == 0 ? 0 : group.members.size() + 1;
     }
 
     @Override

--- a/src/main/java/com/github/manolo8/darkbot/core/objects/group/Group.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/objects/group/Group.java
@@ -18,7 +18,6 @@ public class Group extends Updatable.Auto {
     public GroupMember heroMember = new GroupMember();
 
     public int id;
-    public int size;
     public int maxSize;
     public boolean isOpen; // if the group is open to allowing anyone to invite
     public boolean isLeader;
@@ -53,7 +52,6 @@ public class Group extends Updatable.Auto {
         synchronized (Main.UPDATE_LOCKER) {
             filtered = membersPtr.sync(members, GroupMember::new, m -> m.id != hero.id);
         }
-        size = members.size() + 1;
         heroMember = filtered.stream().findFirst().orElse(null);
         isLeader = heroMember != null && heroMember.isLeader;
         selectedMember = members.stream().filter(m -> selectedAddr == m.address).findFirst().orElse(null);
@@ -61,7 +59,6 @@ public class Group extends Updatable.Auto {
 
     private void reset() {
         members.clear();
-        size = 0;
         isLeader = false;
         heroMember = null;
         selectedMember = null;
@@ -76,14 +73,14 @@ public class Group extends Updatable.Auto {
 
     public int indexOf(int id) {
         if (members.isEmpty()) return -1;
-        for (int i = 0; i < size; i++)
+        for (int i = 0; i < members.size(); i++)
             if (members.get(i).id == id) return i;
         return -1;
     }
 
     public int indexOf(GroupMember member) {
         if (members.isEmpty()) return -1;
-        for (int i = 0; i < size; i++)
+        for (int i = 0; i < members.size(); i++)
             if (members.get(i) == member) return i;
         return -1;
     }


### PR DESCRIPTION
Was searching through group member array, on the assumption hero was part of it.

Example: Self, P1, P2, P3 members in the group
member arraylist: P1, P2, P3
size = member arraylist size + 1
indexOf(P5): this would search for P5 through arraylist based on size, not members in arraylist, causing index out of bounds. 

This update address to fix the issue