### PR TITLE
Fix several editor issues

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/gui/tree/editors/BooleanEditor.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/tree/editors/BooleanEditor.java
@@ -3,7 +3,6 @@ package com.github.manolo8.darkbot.gui.tree.editors;
 import com.github.manolo8.darkbot.gui.AdvancedConfig;
 import eu.darkbot.api.config.ConfigSetting;
 import eu.darkbot.api.config.util.OptionEditor;
-import eu.darkbot.api.config.util.ValueHandler;
 
 import javax.swing.*;
 import java.awt.*;
@@ -24,7 +23,7 @@ public class BooleanEditor extends JCheckBox implements OptionEditor<Boolean> {
 
     @Override
     public Insets getInsets() {
-        return new Insets(0, -1, 0, 0);
+        return new Insets(0, 0, 0, 0);
     }
 
     @Override

--- a/src/main/java/com/github/manolo8/darkbot/gui/tree/editors/PercentEditor.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/tree/editors/PercentEditor.java
@@ -12,7 +12,7 @@ import java.awt.*;
 public class PercentEditor extends JSpinner implements OptionEditor<Double> {
 
     public PercentEditor() {
-        super(new SpinnerNumberMinMaxFix(0, 0d, 1d, 0.05d));
+        super(new SpinnerNumberMinMaxFix(0d, 0d, 1d, 0.05d));
         setEditor(new JSpinner.NumberEditor(this, "0%"));
         ((DefaultEditor) getEditor()).getTextField().setColumns(3);
         addChangeListener(a -> SpinnerUtils.setError(this, false));

--- a/src/main/java/com/github/manolo8/darkbot/gui/tree/editors/RangeEditor.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/tree/editors/RangeEditor.java
@@ -2,6 +2,7 @@ package com.github.manolo8.darkbot.gui.tree.editors;
 
 import com.github.manolo8.darkbot.config.Config;
 import com.github.manolo8.darkbot.gui.AdvancedConfig;
+import com.github.manolo8.darkbot.gui.tree.utils.SizedLabel;
 import eu.darkbot.api.config.ConfigSetting;
 import eu.darkbot.api.config.types.PercentRange;
 import eu.darkbot.api.config.util.OptionEditor;
@@ -17,7 +18,7 @@ public class RangeEditor extends JPanel implements OptionEditor<PercentRange> {
         super(new FlowLayout(FlowLayout.LEFT, 0, 0));
 
         add(min = new PercentEditor());
-        add(new JLabel(" - "));
+        add(new SizedLabel(" - "));
         add(max = new PercentEditor());
 
         min.addChangeListener(e -> {

--- a/src/main/java/com/github/manolo8/darkbot/gui/tree/editors/ShipModeEditor.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/tree/editors/ShipModeEditor.java
@@ -2,10 +2,10 @@ package com.github.manolo8.darkbot.gui.tree.editors;
 
 import com.github.manolo8.darkbot.config.Config;
 import com.github.manolo8.darkbot.gui.AdvancedConfig;
+import com.github.manolo8.darkbot.gui.tree.utils.SizedLabel;
 import eu.darkbot.api.config.ConfigSetting;
 import eu.darkbot.api.config.types.ShipMode;
 import eu.darkbot.api.config.util.OptionEditor;
-import eu.darkbot.api.game.items.SelectableItem;
 import eu.darkbot.api.managers.HeroAPI;
 
 import javax.swing.*;
@@ -32,7 +32,7 @@ public class ShipModeEditor extends JPanel implements OptionEditor<ShipMode> {
             add(configButton);
             configButton.addKeyListener(formationField); // Relay key presses to formation
         }
-        add(new JLabel("      Formation  "));
+        add(new SizedLabel("      Formation  "));
         add(formationField);
     }
 

--- a/src/main/java/com/github/manolo8/darkbot/gui/tree/utils/SizedLabel.java
+++ b/src/main/java/com/github/manolo8/darkbot/gui/tree/utils/SizedLabel.java
@@ -1,0 +1,16 @@
+package com.github.manolo8.darkbot.gui.tree.utils;
+
+import com.github.manolo8.darkbot.gui.AdvancedConfig;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class SizedLabel extends JLabel {
+    public SizedLabel(String text) {
+        super(text);
+    }
+    @Override
+    public Dimension getPreferredSize() {
+        return AdvancedConfig.forcePreferredHeight(super.getPreferredSize());
+    }
+}


### PR DESCRIPTION
Fixes number editor only effectively supporting int, as using other numbers like double would not force the editor to return doubles, meaning it'd attempt to save int to config and throw exceptions.
Also fixes checkbox and enabled status not being in-sync when the renderer is opened.
Also fixes an issue where some editors (range editor and ship mode editor) would have off-by-one pixels vertically on linux due to different default fonts having higher verticals.