### PR TITLE
Improve mem reading performance for quests & assembly

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/Main.java
+++ b/src/main/java/com/github/manolo8/darkbot/Main.java
@@ -65,7 +65,7 @@ public class Main extends Thread implements PluginListener, BotAPI {
     /** Do not use in plugins! Only for bot internal usage */
     @ApiStatus.Internal public static Main INSTANCE;
 
-    public static final Version VERSION      = new Version("1.131");
+    public static final Version VERSION      = new Version("1.131.1 b1");
     public static final Object UPDATE_LOCKER = new Object();
     public static final Gson GSON            = new GsonBuilder()
             .setPrettyPrinting()

--- a/src/main/java/com/github/manolo8/darkbot/Main.java
+++ b/src/main/java/com/github/manolo8/darkbot/Main.java
@@ -65,7 +65,7 @@ public class Main extends Thread implements PluginListener, BotAPI {
     /** Do not use in plugins! Only for bot internal usage */
     @ApiStatus.Internal public static Main INSTANCE;
 
-    public static final Version VERSION      = new Version("1.131.1 b1");
+    public static final Version VERSION      = new Version("1.131.1 b2");
     public static final Object UPDATE_LOCKER = new Object();
     public static final Gson GSON            = new GsonBuilder()
             .setPrettyPrinting()

--- a/src/main/java/com/github/manolo8/darkbot/core/itf/Updatable.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/itf/Updatable.java
@@ -47,10 +47,13 @@ public abstract class Updatable implements NativeUpdatable {
      */
     public abstract static class Reporting extends Updatable {
 
-        public boolean updateAndReport(long address) {
-            boolean addressChanged = this.address != address;
-            super.update(address);
-            return updateAndReport() || addressChanged;
+        public final boolean updateAndReport(long address) {
+            if (this.address != address) {
+                update(address);
+                updateAndReport();
+                return true;
+            }
+            return updateAndReport();
         }
 
         @Override

--- a/src/main/java/com/github/manolo8/darkbot/core/itf/Updatable.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/itf/Updatable.java
@@ -9,6 +9,12 @@ public abstract class Updatable implements NativeUpdatable {
 
     public abstract void update();
 
+    public final void updateIfChanged(long address) {
+        if (this.address != address) {
+            update(address);
+        }
+    }
+
     public void update(long address) {
         this.address = address;
     }

--- a/src/main/java/com/github/manolo8/darkbot/core/objects/facades/AssemblyMediator.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/objects/facades/AssemblyMediator.java
@@ -1,6 +1,5 @@
 package com.github.manolo8.darkbot.core.objects.facades;
 
-import com.github.manolo8.darkbot.Main;
 import com.github.manolo8.darkbot.core.itf.Updatable;
 import com.github.manolo8.darkbot.core.objects.swf.FlashList;
 import com.github.manolo8.darkbot.core.objects.swf.FlashListLong;
@@ -91,10 +90,8 @@ public class AssemblyMediator extends Updatable implements AssemblyAPI {
             long data = readAtom(0x58, 0x40, 0x20);
             visibility = API.readString(data, 0x90);
             craftTimeData.update(API.readAtom(data, 0x98));
-            for (long i : craftTimeData) {
-                craftTimeRequired = API.readInt(i, 0x24);
-                break;
-            }
+            if (!craftTimeData.isEmpty())
+                craftTimeRequired = API.readInt(craftTimeData.getLong(0), 0x24);
             isInProgress = craftTimeLeft > 0 && craftTimeLeft <= craftTimeRequired;
             isCollectable = !isInProgress && API.readDouble(data, 0x28) == 1.0;
         }
@@ -123,10 +120,9 @@ public class AssemblyMediator extends Updatable implements AssemblyAPI {
 
         @Override
         public boolean updateAndReport() {
-            if (address <= 0) return false;
+            if (address == 0) return false;
 
-            return first.updateAndReport(Main.API.readAtom(address + 0x20))
-                    || second.updateAndReport(Main.API.readAtom(address + 0x28));
+            return first.updateAndReport(readAtom(0x20)) | second.updateAndReport(readAtom(0x28));
         }
     }
 
@@ -139,12 +135,18 @@ public class AssemblyMediator extends Updatable implements AssemblyAPI {
         private double x, y;
 
         @Override
-        public boolean updateAndReport() {
-            if (address <= 0) return false;
+        public void update(long address) {
+            super.update(address);
             filterName = API.readString(address, 0x20);
-            isChecked = API.readBoolean(address, 0x28, 0x1D0);
-            x = API.readDouble(address, 0x28, 0x158);
-            y = API.readDouble(address, 0x28, 0x160);
+        }
+
+        @Override
+        public boolean updateAndReport() {
+            if (address == 0) return false;
+            var data = readAtom(0x28);
+            isChecked = API.readBoolean(data, 0x1D0);
+            x = API.readDouble(data, 0x158);
+            y = API.readDouble(data, 0x160);
             // Always false, we only care about address itself changing, which reports true regardless
             return false;
         }

--- a/src/main/java/com/github/manolo8/darkbot/core/objects/facades/BoosterProxy.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/objects/facades/BoosterProxy.java
@@ -24,7 +24,7 @@ public class BoosterProxy extends Updatable implements BoosterAPI {
         }
     }
 
-    public static class Booster extends Auto implements BoosterAPI.Booster {
+    public static class Booster extends Updatable implements BoosterAPI.Booster {
         public double amount, cd;
         public String category, name;
 
@@ -37,12 +37,17 @@ public class BoosterProxy extends Updatable implements BoosterAPI {
         private final FlashListLong categoriesArr = FlashListLong.ofVector();
 
         @Override
-        public void update() {
+        public void update(long address) {
+            super.update(address);
             String oldCat = this.category;
             this.category = readString(0x20);
             if (!Objects.equals(this.category, oldCat))
                 this.cat = BoosterAPI.Type.of(category);
             this.name = readString(0x40); //0x48 description;
+        }
+
+        @Override
+        public void update() {
             this.amount = readDouble(0x50);
             this.subBoostersArr.update(readLong(0x30));
 

--- a/src/main/java/com/github/manolo8/darkbot/core/objects/facades/DiminishQuestMediator.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/objects/facades/DiminishQuestMediator.java
@@ -23,7 +23,8 @@ public class DiminishQuestMediator extends Updatable implements API.Singleton {
         int stateIndex = API.readInt(address, 0x50, 0x40) + 1;
         if (stateIndex >= 0 && stateIndex < STATES.length) {
             state = STATES[stateIndex];
-            diminishQuest.update(API.readAtom(address, 0x50, 0x60));
+            diminishQuest.updateIfChanged(API.readAtom(address, 0x50, 0x60));
+            diminishQuest.update();
         } else {
             state = State.NOT_EXIST;
         }

--- a/src/main/java/com/github/manolo8/darkbot/core/objects/facades/DispatchRetrieverProxy.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/objects/facades/DispatchRetrieverProxy.java
@@ -26,12 +26,13 @@ public class DispatchRetrieverProxy extends Updatable implements API.Singleton {
         availableRetrievers.update(API.readAtom(dispatchRetrieverData + 0x58));
         inProgressRetrievers.update(API.readAtom(dispatchRetrieverData + 0x60));
 
-        selectedRetriever.update(API.readAtom(dispatchRetrieverData + 0x68));
+        selectedRetriever.updateIfChanged(API.readAtom(dispatchRetrieverData + 0x68));
+        selectedRetriever.update();
     }
 
     @Getter
     @ToString
-    private static class Retriever extends Auto implements DispatchAPI.Retriever {
+    private static class Retriever extends Updatable implements DispatchAPI.Retriever {
         private int id = -1, slotId = -1, tier = -1;
         private String iconId = "", type = "", name = "", descriptionId = "";
         private double duration = -1;
@@ -39,6 +40,22 @@ public class DispatchRetrieverProxy extends Updatable implements API.Singleton {
 
         private final FlashList<Cost> costList =  FlashList.ofVector(Cost::new);
         private final Cost instantCost = new Cost();
+
+        @Override
+        public void update(long address) {
+            super.update(address);
+
+            long retrieverDefinition = readAtom(0x38);
+            this.id = API.readInt(retrieverDefinition, 0x20); // 1 to 18
+            this.tier = API.readInt(retrieverDefinition, 0x24); // 1, 2, 3, 4, 5 or 6
+            this.iconId = API.readString(retrieverDefinition, 0x30); // dispatch_retriever_r01
+            this.name = API.readString(retrieverDefinition, 0x38); // R-01
+            this.type = API.readString(retrieverDefinition, 0x40); // resource
+            this.descriptionId = API.readString(retrieverDefinition, 0x48); // dispatch_label_description_retriever_r01
+            this.costList.update(API.readAtom(retrieverDefinition, 0x50));
+
+            this.instantCost.update(API.readAtom(retrieverDefinition, 0x58));
+        }
 
         @Override
         public void update() {
@@ -49,17 +66,6 @@ public class DispatchRetrieverProxy extends Updatable implements API.Singleton {
             long dispatchModule = API.readAtom(address + 0x30);
             this.slotId = API.readInt(dispatchModule + 0x20); // 0 for available, 1 to 5 for in-progress
             this.duration = API.readDouble(dispatchModule + 0x28); // time left in seconds, or total time
-
-            long retrieverDefinition = API.readAtom(address + 0x38);
-            this.id = API.readInt(retrieverDefinition + 0x20); // 1 to 18
-            this.tier = API.readInt(retrieverDefinition + 0x24); // 1, 2, 3, 4, 5 or 6
-            this.iconId = API.readString(retrieverDefinition, 0x30); // dispatch_retriever_r01
-            this.name = API.readString(retrieverDefinition, 0x38); // R-01
-            this.type = API.readString(retrieverDefinition, 0x40); // resource
-            this.descriptionId = API.readString(retrieverDefinition, 0x48); // dispatch_label_description_retriever_r01
-            this.costList.update(API.readAtom(retrieverDefinition + 0x50));
-
-            this.instantCost.update(API.readAtom(retrieverDefinition + 0x58));
         }
 
     }

--- a/src/main/java/com/github/manolo8/darkbot/core/objects/facades/QuestProxy.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/objects/facades/QuestProxy.java
@@ -10,8 +10,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static com.github.manolo8.darkbot.Main.API;
-
 public class QuestProxy extends Updatable implements QuestAPI {
     private boolean questsUpdated = false;
 
@@ -174,7 +172,7 @@ public class QuestProxy extends Updatable implements QuestAPI {
             super.update(address);
 
             this.requirements.update(readAtom(0x48));
-            this.type = API.readString(0x58, 0x28);
+            this.type = readString(0x58, 0x28);
             this.description = readString(0x60);
         }
 

--- a/src/main/java/com/github/manolo8/darkbot/core/objects/facades/SeassonPassMediator.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/objects/facades/SeassonPassMediator.java
@@ -3,18 +3,16 @@ package com.github.manolo8.darkbot.core.objects.facades;
 import com.github.manolo8.darkbot.core.itf.Updatable;
 import com.github.manolo8.darkbot.core.objects.facades.QuestProxy.Quest;
 import com.github.manolo8.darkbot.core.objects.swf.FlashList;
-
 import eu.darkbot.api.managers.QuestAPI;
 import eu.darkbot.api.managers.SeassonPassAPI;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.ToString;
-
-import static com.github.manolo8.darkbot.Main.API;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import org.jetbrains.annotations.Nullable;
+import static com.github.manolo8.darkbot.Main.API;
 
 public class SeassonPassMediator extends Updatable implements SeassonPassAPI {
 
@@ -119,13 +117,19 @@ public class SeassonPassMediator extends Updatable implements SeassonPassAPI {
         private final QuestProxy.Quest quest = new Quest();
 
         @Override
+        public void update(long address) {
+            super.update(address);
+            this.quest.update(readAtom(0x40));
+        }
+
+        @Override
         public void update() {
             this.isGoldMission = readBoolean(20);
             this.goldLocked = readBoolean(24);
             this.oncePreMission = readBoolean(28);
-            this.status = API.readInt(API.readAtom(address + 0x48) + 0x20);
+            this.status = readInt(0x48, 0x20);
 
-            this.quest.update(API.readAtom(address, 0x40));
+            this.quest.update();
         }
 
         public @Nullable QuestAPI.Quest getQuest() {

--- a/src/main/java/com/github/manolo8/darkbot/core/objects/facades/SeassonPassMediator.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/objects/facades/SeassonPassMediator.java
@@ -56,7 +56,6 @@ public class SeassonPassMediator extends Updatable implements SeassonPassAPI {
         if (questDataAddr == 0) {
             return;
         }
-
         dailyQuests.update(API.readAtom(questDataAddr + 0x60));
         weeklyQuests.update(API.readAtom(questDataAddr + 0x68));
         seassonQuests.update(API.readAtom(questDataAddr + 0x70));


### PR DESCRIPTION
Quest & assembly are atm a big part of the memory reading footpring, this PR modifies them to be more careful & aware about what data they read only on address change (ie: immutable data) and which they read on each pass