### PR TITLE
Ignore PET while jumping

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/config/Config.java
+++ b/src/main/java/com/github/manolo8/darkbot/config/Config.java
@@ -173,6 +173,7 @@ public class Config implements eu.darkbot.api.config.legacy.Config {
     public static class PetSettings {
         public @Option boolean ENABLED = false;
         public @Option @Dropdown(options = PetGears.class) PetGear MODULE_ID = PetGear.PASSIVE;
+        public @Option boolean IGNORE_WHILE_JUMPING = false;
     }
 
     public @Option GroupSettings GROUP = new GroupSettings();

--- a/src/main/java/com/github/manolo8/darkbot/core/manager/PetManager.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/manager/PetManager.java
@@ -89,6 +89,7 @@ public class PetManager extends Gui implements PetAPI {
     private Integer gearOverride = null;
     private long gearOverrideTime = 0;
     private boolean repaired = true;
+    private long portalJumpingUntil = 0;
 
     private final Map<PetStatsType, PetStats> petStats = new EnumMap<>(PetStatsType.class);
 
@@ -123,7 +124,7 @@ public class PetManager extends Gui implements PetAPI {
     }
 
     public void tick() {
-        if (!main.isRunning() || !main.config.PET.ENABLED) return;
+        if (!main.isRunning() || !main.config.PET.ENABLED || isIgnoreWhileJumping()) return;
 
         eu.darkbot.api.extensions.selectors.PetGearSupplier gearSupplier = gearSelectorHandler.getBestSupplier();
 
@@ -219,6 +220,21 @@ public class PetManager extends Gui implements PetAPI {
     @Override
     public boolean isRepaired() {
         return repaired;
+    }
+
+    private boolean isIgnoreWhileJumping() {
+        if (main.config.PET.IGNORE_WHILE_JUMPING) {
+            // Determine if the hero is currently jumping through a portal
+            if (main.mapManager.entities.portals.stream().anyMatch(portal -> portal.isJumping())) {
+                portalJumpingUntil = System.currentTimeMillis() + 3000; // Add 3 seconds to the jumping time
+                return true;
+            }
+            // Waiting for map loading
+            if (System.currentTimeMillis() < portalJumpingUntil) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean active() {

--- a/src/main/resources/lang/strings_en.properties
+++ b/src/main/resources/lang/strings_en.properties
@@ -175,6 +175,8 @@ config.pet.enabled=Use PET
 config.pet.enabled.desc=If disabled, bot will ignore all PET functions
 config.pet.module_id=PET module
 config.pet.module.desc=The list will update to your modules if your PET is on
+config.pet.ignore_while_jumping=Ignore PET while jumping
+config.pet.ignore_while_jumping.desc=If enabled, bot will ignore PET modules while jumping to another map
 
 config.group=Group
 config.group.accept_invites=Accept invites


### PR DESCRIPTION
Future request: https://discord.com/channels/523159099870019584/564190622492262402/1360725629191852293

Name of feature: General -> PET:  Add checkbox "Ignore PET while jumping"

Description: If I use PET in "Guard mode", then every time when escaping and jumping, or when traveling to another map and jumping to the gate, the bot switching the PET to "Guard mode" . 
This causes an issue where the PET window can get stuck.