### PR TITLE
Disable an active PET when it is disabled in config

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/core/manager/PetManager.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/manager/PetManager.java
@@ -123,7 +123,16 @@ public class PetManager extends Gui implements PetAPI {
     }
 
     public void tick() {
-        if (!main.isRunning() || !main.config.PET.ENABLED) return;
+        if (!main.isRunning()) return;
+
+        if (!main.config.PET.ENABLED) {
+            if (active()) {
+                if (show(true)) clickToggleStatus();
+                hide();
+                return;
+            }
+            return;
+        }
 
         eu.darkbot.api.extensions.selectors.PetGearSupplier gearSupplier = gearSelectorHandler.getBestSupplier();
 


### PR DESCRIPTION
A small change to disable a currently active PET if the "Use PET" setting is disabled in config.

I'm new to this, feedback is welcome.