### PR TITLE
[Dev Feature] Method signature scanning to handle InvalidNativeSignature exceptions.

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/core/api/Utils.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/api/Utils.java
@@ -9,6 +9,7 @@ import com.github.manolo8.darkbot.core.utils.pathfinder.RectangleImpl;
 import com.github.manolo8.darkbot.utils.MathUtils;
 
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 public class Utils {
     public static final String SELECT_MAP_ASSET = "MapAssetNotificationTRY_TO_SELECT_MAPASSET";
@@ -97,6 +98,31 @@ public class Utils {
             }
 
             return true;
+        }
+
+        default CompletableFuture<Void> scanMethodSignature(boolean checkName, String signature, int index, long object) {
+            return CompletableFuture.runAsync(() -> {
+                if (!ByteUtils.isValidPtr(object)) {
+                    System.out.println("[SignatureScan] invalid object for signature: " + signature);
+                    return;
+                }
+
+                int scanWindow = 20;
+                int fromIndex = Math.max(0, index - scanWindow);
+                int toIndex = index + scanWindow;
+
+                boolean found = false;
+                for (int idx = fromIndex; idx <= toIndex; idx++) {
+                    int result = checkMethodSignature(object, idx, checkName, signature);
+                    if (result == 1) {
+                        found = true;
+                        System.out.println("[SignatureScan] match at index " + idx + ": " + signature);
+                    }
+                }
+                if (!found) {
+                    System.out.println("[SignatureScan] no match in range " + fromIndex + ".." + toIndex + ": " + signature);
+                }
+            });
         }
     }
 

--- a/src/main/java/com/github/manolo8/darkbot/core/api/adapters/KekkaPlayerAdapter.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/api/adapters/KekkaPlayerAdapter.java
@@ -4,6 +4,7 @@ import com.github.manolo8.darkbot.config.Config;
 import com.github.manolo8.darkbot.core.BotInstaller;
 import com.github.manolo8.darkbot.core.api.Capability;
 import com.github.manolo8.darkbot.core.api.GameAPIImpl;
+import com.github.manolo8.darkbot.core.api.InvalidNativeSignature;
 import com.github.manolo8.darkbot.core.api.Utils;
 import com.github.manolo8.darkbot.core.entities.Box;
 import com.github.manolo8.darkbot.core.entities.Entity;
@@ -159,8 +160,13 @@ public class KekkaPlayerAdapter extends GameAPIImpl<
 
         @Override
         public boolean callMethodChecked(boolean checkName, String signature, int index, long... arguments) {
-            if (checkSignature(checkName, signature, index, arguments[0]))
-                return callMethodAsync(index, arguments);
+            try {
+                if (checkSignature(checkName, signature, index, arguments[0]))
+                    return callMethodAsync(index, arguments);
+            } catch (InvalidNativeSignature e) {
+                scanMethodSignature(checkName, signature, index, arguments[0]);
+                throw e;
+            }
 
             return false;
         }

--- a/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
@@ -4,6 +4,7 @@ import com.github.manolo8.darkbot.Main;
 import com.github.manolo8.darkbot.core.BotInstaller;
 import com.github.manolo8.darkbot.core.api.Capability;
 import com.github.manolo8.darkbot.core.api.GameAPIImpl;
+import com.github.manolo8.darkbot.core.api.InvalidNativeSignature;
 import com.github.manolo8.darkbot.core.api.Utils;
 import com.github.manolo8.darkbot.core.entities.Box;
 import com.github.manolo8.darkbot.core.entities.Entity;
@@ -79,9 +80,14 @@ public class TanosAdapter extends GameAPIImpl<
 
         @Override
         public boolean callMethodChecked(boolean checkName, String signature, int index, long... arguments) {
-            if (checkSignature(checkName, signature, index, arguments[0])) {
-                callMethod(index, arguments);
-                return true;
+            try {
+                if (checkSignature(checkName, signature, index, arguments[0])) {
+                    callMethod(index, arguments);
+                    return true;
+                }
+            } catch (InvalidNativeSignature e) {
+                scanMethodSignature(checkName, signature, index, arguments[0]);
+                throw e;
             }
             return false;
         }


### PR DESCRIPTION
Example of how it works (for the last fixed [AD Offer](https://github.com/darkbot-reloaded/DarkBot/pull/441) issue):
```
 com.github.manolo8.darkbot.core.api.InvalidNativeSignature: Invalid flash method signature! 23(2626)1016321600
 	at com.github.manolo8.darkbot.core.api.Utils$SignatureChecker.checkSignature(Utils.java:96)
 	at com.github.manolo8.darkbot.core.api.adapters.TanosAdapter$DirectInteractionManager.callMethodChecked(TanosAdapter.java:84)
 	at com.github.manolo8.darkbot.core.api.GameAPIImpl.callMethodChecked(GameAPIImpl.java:532)
 	at com.github.manolo8.darkbot.core.objects.gui.TargetedOfferGui.close(TargetedOfferGui.java:41)
 	at com.github.manolo8.darkbot.core.objects.Gui.show(Gui.java:126)
 	at com.github.manolo8.darkbot.core.objects.gui.TargetedOfferGui.show(TargetedOfferGui.java:34)
 	at com.github.manolo8.darkbot.core.manager.GuiManager.tick(GuiManager.java:214)
 	at com.github.manolo8.darkbot.Main.validTick(Main.java:270)
 	at com.github.manolo8.darkbot.Main.tick(Main.java:233)
 	at com.github.manolo8.darkbot.Main.run(Main.java:204)
 [SignatureScan] match at index 275: 23(2626)1016321600
 [SignatureScan] match at index 283: 23(2626)1016321600
```
We can simply take a new index from the log 
`[SignatureScan] match at index 283: 23(2626)1016321600`
and quickly fix the problem.

Also, to not always keep it enabled, there may be settings in the bot to enable it only if necessary.