### PR TITLE
Signature resolver to maintain compatibility with the Tanos API

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
@@ -15,6 +15,7 @@ import eu.darkbot.api.game.other.Locatable;
 import eu.darkbot.api.managers.OreAPI;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class TanosAdapter extends GameAPIImpl<
@@ -121,7 +122,18 @@ public class TanosAdapter extends GameAPIImpl<
 
         @Override
         public int checkMethodSignature(long obj, int methodIdx, boolean includeMethodName, String signature) {
-            return tanos.checkMethodSignature(obj, methodIdx, includeMethodName, signature);
+            return tanos.checkMethodSignature(obj, methodIdx, includeMethodName, resolveSignature(signature));
+        }
+
+        /**
+         * Resolves known signature changes to maintain compatibility with the Tanos API
+         */
+        private String resolveSignature(String signature) {
+            // format: oldSignature -> newSignature
+            Map<String, String> signatureOverrides = Map.of(
+                "23(set target)(2626)1016221500", "23(target)(2626)1016221500"
+            );
+            return signatureOverrides.getOrDefault(signature, signature);
         }
 
     }


### PR DESCRIPTION
This fix is related to targeting the Relay in the LoW gate.

The signature `23(set target)(2626)1016221500` check called from the `MapManager`
https://github.com/darkbot-reloaded/DarkBot/blob/f9969bef4b6f26fb643a1f818ec506f2044b22d2/src/main/java/com/github/manolo8/darkbot/core/manager/MapManager.java#L434-L440

And this signature works fine for the Kekka Player API.
However, for the Tanos API, it always returns an error: "Invalid flash method signature!"
The correct signature for Tanos API is `23(target)(2626)1016221500`

I'm not sure whether this is the correct place or method to specify a different signature for Tanos API only.
Please review and let me know.