### PR TITLE
Implement getVersion method in TanosAdapter and added missing label for API select

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
@@ -56,6 +56,11 @@ public class TanosAdapter extends GameAPIImpl<
         return false;
     }
 
+    @Override
+    public String getVersion() {
+        return "Tanos-" + window.getVersion();
+    }
+
     public static class DirectInteractionManager extends NoopAPIAdapter.NoOpDirectInteraction
             implements Utils.SignatureChecker {
 

--- a/src/main/resources/lang/strings_en.properties
+++ b/src/main/resources/lang/strings_en.properties
@@ -579,6 +579,8 @@ verifier.panel.authenticated.blacklisted=You are a member of blacklisted servers
 # Browser apis
 browser_api.kekka_player=KekkaPlayer API (Recommended)
 browser_api.kekka_player.desc=Currently recommended API, flash container with no browser, by Punisher
+browser_api.tanos_api=Tanos API (For Linux)
+browser_api.tanos_api.desc=API for Linux users, runs the client in Electron browser
 browser_api.dark_boat=KekkaPlayer API (Recommended)
 browser_api.dark_boat.desc=Currently recommended API, flash container with no browser, by Punisher
 browser_api.dark_boat_hook=KekkaPlayer with DarkHook (Experimental)


### PR DESCRIPTION
Implemented `getVersion` method in the same way as in `KekkaPlayerAdapter` 
To make it more beautiful then current one:
<img width="236" height="145" alt="image" src="https://github.com/user-attachments/assets/7ad51948-1364-4688-a7e8-cf5b8a3c15e3" />

Also, I added a missing label for the `tanos_api` select option:
<img width="314" height="107" alt="image" src="https://github.com/user-attachments/assets/ed8bca6a-2dd0-4322-92bf-b90f2a5a8281" />
