### PR TITLE
Native mouse and keyboard actions for Tanos API

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/core/IDarkBotAPI.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/IDarkBotAPI.java
@@ -123,6 +123,9 @@ public interface IDarkBotAPI extends WindowAPI, MemoryAPI {
     // LOW = 0, MEDIUM = 1, HIGH = 2, BEST = 3, AUTO_LOW = 4, AUTO_HIGH = 5
     void setQuality(GameAPI.Handler.GameQuality quality);
 
+    // Show red marker on the screen where the mouse cursor is, when enabled
+    void setCursorMarker(boolean enable);
+
     long lastInternetReadTime();
     //</editor-fold>
 }

--- a/src/main/java/com/github/manolo8/darkbot/core/api/GameAPI.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/api/GameAPI.java
@@ -67,6 +67,8 @@ public interface GameAPI {
         default void setVolume(int volume) {} // 0 - 100
         // LOW = 0, MEDIUM = 1, HIGH = 2, BEST = 3, AUTO_LOW = 4, AUTO_HIGH = 5
         default void setQuality(int quality) {}
+        // Show red marker on the screen where the mouse cursor is, when enabled
+        default void setCursorMarker(boolean enable) {}
 
         default long lastInternetReadTime() {
             return 0;

--- a/src/main/java/com/github/manolo8/darkbot/core/api/GameAPIImpl.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/api/GameAPIImpl.java
@@ -614,6 +614,11 @@ public class GameAPIImpl<
     }
 
     @Override
+    public void setCursorMarker(boolean enable) {
+        throw new UnsupportedOperationException("setCursorMarker not implemented!");
+    }
+
+    @Override
     public long lastInternetReadTime() {
         return handler.lastInternetReadTime();
     }

--- a/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
@@ -67,6 +67,11 @@ public class TanosAdapter extends GameAPIImpl<
         window.postActions(actions);
     }
 
+    @Override
+    public void pasteText(String text, long... actions) {
+        window.pasteText(text, actions);
+    }
+
     public static class DirectInteractionManager extends NoopAPIAdapter.NoOpDirectInteraction
             implements Utils.SignatureChecker {
 

--- a/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
@@ -58,6 +58,11 @@ public class TanosAdapter extends GameAPIImpl<
     }
 
     @Override
+    public void setCursorMarker(boolean enable) {
+        handler.setCursorMarker(enable);
+    }
+
+    @Override
     public void postActions(long... actions) {
         window.postActions(actions);
     }

--- a/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
@@ -36,6 +36,7 @@ public class TanosAdapter extends GameAPIImpl<
                 Capability.DIRECT_ENTITY_SELECT,
                 Capability.DIRECT_MOVE_SHIP,
                 Capability.DIRECT_COLLECT_BOX,
+                Capability.DIRECT_POST_ACTIONS,
                 Capability.DIRECT_REFINE,
                 Capability.DIRECT_USE_ITEM,
                 Capability.DIRECT_CALL_METHOD);
@@ -54,6 +55,11 @@ public class TanosAdapter extends GameAPIImpl<
         }
 
         return false;
+    }
+
+    @Override
+    public void postActions(long... actions) {
+        window.postActions(actions);
     }
 
     public static class DirectInteractionManager extends NoopAPIAdapter.NoOpDirectInteraction

--- a/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/api/adapters/TanosAdapter.java
@@ -33,6 +33,7 @@ public class TanosAdapter extends GameAPIImpl<
                 Capability.LOGIN,
                 Capability.INITIALLY_SHOWN,
                 Capability.CREATE_WINDOW_THREAD,
+                Capability.ALL_KEYBINDS_SUPPORT,
                 Capability.DIRECT_ENTITY_SELECT,
                 Capability.DIRECT_MOVE_SHIP,
                 Capability.DIRECT_COLLECT_BOX,

--- a/src/main/java/eu/darkbot/api/DarkTanos.java
+++ b/src/main/java/eu/darkbot/api/DarkTanos.java
@@ -30,6 +30,8 @@ public class DarkTanos implements GameAPI.Window, GameAPI.Handler, GameAPI.Memor
     public native void mouseUp   (int x, int y);
     public native void mouseClick(int x, int y);
 
+    public native void postActions(long... actions);
+
     public native int     readInt    (long address);
     public native long    readLong   (long address);
     public native double  readDouble (long address);

--- a/src/main/java/eu/darkbot/api/DarkTanos.java
+++ b/src/main/java/eu/darkbot/api/DarkTanos.java
@@ -21,6 +21,8 @@ public class DarkTanos implements GameAPI.Window, GameAPI.Handler, GameAPI.Memor
     public native boolean isValid();
     public native long    getMemoryUsage();
     public native int     getVersion();
+    // Show red marker on the screen where the mouse cursor is, when enabled
+    public native void setCursorMarker(boolean enable);
 
     public native void keyClick  (int keyCode);
     public native void sendText  (String text);

--- a/src/main/java/eu/darkbot/api/DarkTanos.java
+++ b/src/main/java/eu/darkbot/api/DarkTanos.java
@@ -33,6 +33,7 @@ public class DarkTanos implements GameAPI.Window, GameAPI.Handler, GameAPI.Memor
     public native void mouseClick(int x, int y);
 
     public native void postActions(long... actions);
+    public native void pasteText(String text, long... actions);
 
     public native int     readInt    (long address);
     public native long    readLong   (long address);


### PR DESCRIPTION
Related updated for Tanos lib and browser https://github.com/do-gamer/do_lib/pull/4

1) Implemented `postActions(long... actions)` and `pasteText(String text, long... actions)`
This is related to [native actions](https://github.com/darkbot-reloaded/DarkBot/blob/master/src/main/java/eu/darkbot/api/utils/NativeAction.java) which for now works only in Kekka Player API

2) Added `setCursorMarker(boolean enable)`  (for testing)
Red dot marker to visualize where exactly the bot is clicking. It can be helpful for developing plugins that require clicks.