### PR TITLE
Reset lastDeath on revive timeout to prevent consecutive refreshes.

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/core/manager/GuiManager.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/manager/GuiManager.java
@@ -301,6 +301,7 @@ public class GuiManager implements Manager, GameScreenAPI {
                 // Refresh if stuck on revive for 90 seconds, revive locations may have different cooldowns
                 if ((System.currentTimeMillis() - lastDeath - main.config.GENERAL.SAFETY.WAIT_BEFORE_REVIVE * 1000L) > 90_000) {
                     triggerRefresh("Triggering refresh: stuck on revive for too long!", false);
+                    lastDeath = -1; // Reset so consecutive refreshes don't fire immediately after reconnect
                 }
 
                 return false;


### PR DESCRIPTION
This fix related to https://github.com/darkbot-reloaded/DarkBot/issues/391 report.

Log of the bug
```
[2026/05/02 23:28:35.560 | db.core.manager.GuiManager.triggerRefresh(GuiManager.java:286)] Triggering refresh: stuck on revive for too long!
[2026/05/02 23:28:45.255 | db.core.manager.GuiManager.triggerRefresh(GuiManager.java:286)] Triggering refresh: stuck on revive for too long!
[2026/05/02 23:28:52.103 | db.core.manager.GuiManager.triggerRefresh(GuiManager.java:286)] Triggering refresh: stuck on revive for too long!
[2026/05/02 23:28:58.639 | db.core.manager.GuiManager.triggerRefresh(GuiManager.java:286)] Triggering refresh: stuck on revive for too long!
[2026/05/02 23:29:06.592 | db.core.manager.GuiManager.triggerRefresh(GuiManager.java:286)] Triggering refresh: stuck on revive for too long!
[2026/05/02 23:29:15.772 | db.core.manager.GuiManager.triggerRefresh(GuiManager.java:286)] Triggering refresh: stuck on revive for too long!
[2026/05/02 23:29:24.687 | db.core.manager.GuiManager.triggerRefresh(GuiManager.java:286)] Triggering refresh: stuck on revive for too long!
[2026/05/02 23:29:33.198 | db.core.manager.GuiManager.triggerRefresh(GuiManager.java:286)] Triggering refresh: stuck on revive for too long!
[2026/05/02 23:29:40.748 | db.core.manager.GuiManager.triggerRefresh(GuiManager.java:286)] Triggering refresh: stuck on revive for too long!
[2026/05/02 23:29:49.300 | db.core.manager.GuiManager.triggerRefresh(GuiManager.java:286)] Triggering refresh: stuck on revive for too long!
[2026/05/02 23:29:58.109 | db.core.manager.GuiManager.triggerRefresh(GuiManager.java:286)] Triggering refresh: stuck on revive for too long!
```
