### PR TITLE
Fix incorrect NPC map list registration during transitions

### DIFF
--- a/src/main/java/com/github/manolo8/darkbot/Main.java
+++ b/src/main/java/com/github/manolo8/darkbot/Main.java
@@ -263,8 +263,8 @@ public class Main extends Thread implements PluginListener, BotAPI {
 
     private void validTick() {
         settingsManager.tick();
-        hero.tick();
         mapManager.tick();
+        hero.tick();
         facadeManager.tick();
         effectManager.tick();
         guiManager.tick();

--- a/src/main/java/com/github/manolo8/darkbot/config/ConfigEntity.java
+++ b/src/main/java/com/github/manolo8/darkbot/config/ConfigEntity.java
@@ -50,7 +50,7 @@ public class ConfigEntity {
 
             info.name = name;
             info.radius = 560;
-            info.mapList.add(mapId);
+            if (mapId > 0) info.mapList.add(mapId);
 
             if (!name.isEmpty()) {
                 npcs.put(name, info);
@@ -58,7 +58,7 @@ public class ConfigEntity {
                 npcInfos.setValue(npcs);
                 changed();
             }
-        } else if (info.mapList.add(mapId)) {
+        } else if (mapId > 0 && info.mapList.add(mapId)) {
             npcInfos.setValue(npcs);
             changed();
         }

--- a/src/main/java/com/github/manolo8/darkbot/core/manager/MapManager.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/manager/MapManager.java
@@ -145,10 +145,10 @@ public class MapManager implements Manager, StarSystemAPI {
         int currMap = API.readInt(address + 84);
         boolean switched = currMap != id;
 
+        entities.update(address);
+
         if (switched)
             switchMap(main.starManager.byId(currMap));
-
-        entities.update(address);
     }
 
     private int lastNextMap;

--- a/src/main/java/com/github/manolo8/darkbot/core/manager/MapManager.java
+++ b/src/main/java/com/github/manolo8/darkbot/core/manager/MapManager.java
@@ -145,10 +145,12 @@ public class MapManager implements Manager, StarSystemAPI {
         int currMap = API.readInt(address + 84);
         boolean switched = currMap != id;
 
-        entities.update(address);
-
-        if (switched)
+        if (switched) {
+            entities.clear();
             switchMap(main.starManager.byId(currMap));
+        }
+
+        entities.update(address);
     }
 
     private int lastNextMap;


### PR DESCRIPTION
- Reordered entity update and map switch in MapManager to prevent old entities from being associated with new map IDs.
- Added validation in ConfigEntity to ensure only positive map IDs are added to NpcInfo mapList.